### PR TITLE
update erb cases to use Erubis; rerun all cases

### DIFF
--- a/01_hello/deas-0.25.0/bench_results.txt
+++ b/01_hello/deas-0.25.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    30.84ms   24.18ms  76.07ms   74.65%
-    Req/Sec   211.86    114.24   368.00     70.42%
-  846 requests in 2.00s, 237.39KB read
-  Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    422.50
-Transfer/sec:    118.55KB
+    Latency    33.36ms   25.84ms  75.50ms   69.23%
+    Req/Sec   212.89    111.76   371.00     63.08%
+  850 requests in 2.00s, 239.06KB read
+  Socket errors: connect 0, read 2, write 0, timeout 0
+Requests/sec:    424.93
+Transfer/sec:    119.51KB

--- a/01_hello/deas-0.27.0/bench_results.txt
+++ b/01_hello/deas-0.27.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    32.13ms   24.92ms  73.25ms   70.73%
-    Req/Sec   219.13    118.42   351.00     69.51%
-  861 requests in 2.00s, 241.86KB read
-  Socket errors: connect 0, read 8, write 0, timeout 0
-Requests/sec:    430.40
-Transfer/sec:    120.90KB
+    Latency    35.98ms   26.60ms  76.01ms   64.18%
+    Req/Sec   209.79    115.39   348.00     65.67%
+  840 requests in 2.00s, 235.70KB read
+  Socket errors: connect 0, read 4, write 0, timeout 0
+Requests/sec:    419.98
+Transfer/sec:    117.85KB

--- a/01_hello/deas-0.28.0/bench_results.txt
+++ b/01_hello/deas-0.28.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    32.34ms   26.42ms  77.78ms   71.01%
-    Req/Sec   219.78    124.11   375.00     71.01%
-  866 requests in 2.00s, 243.54KB read
-  Socket errors: connect 0, read 9, write 0, timeout 0
-Requests/sec:    432.93
-Transfer/sec:    121.75KB
+    Latency    31.79ms   24.61ms  72.95ms   70.89%
+    Req/Sec   219.67    122.70   378.00     65.82%
+  858 requests in 2.00s, 241.02KB read
+  Socket errors: connect 0, read 4, write 0, timeout 0
+Requests/sec:    428.91
+Transfer/sec:    120.49KB

--- a/01_hello/sinatra-1.4.5/bench_results.txt
+++ b/01_hello/sinatra-1.4.5/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    33.12ms   26.50ms  78.43ms   68.67%
-    Req/Sec   232.40    130.07   411.00     69.88%
-  909 requests in 2.00s, 255.32KB read
-  Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    454.33
-Transfer/sec:    127.61KB
+    Latency    28.61ms   23.19ms  69.72ms   75.00%
+    Req/Sec   230.58    126.16   384.00     69.74%
+  906 requests in 2.00s, 254.20KB read
+  Socket errors: connect 0, read 7, write 0, timeout 0
+Requests/sec:    452.88
+Transfer/sec:    127.07KB

--- a/02_erb_basic/deas-0.25.0/Gemfile
+++ b/02_erb_basic/deas-0.25.0/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
 gem "deas", "= 0.25.0"
+gem "erubis",  "~> 2.7"

--- a/02_erb_basic/deas-0.25.0/Gemfile.lock
+++ b/02_erb_basic/deas-0.25.0/Gemfile.lock
@@ -5,6 +5,7 @@ GEM
       ns-options (~> 1.1, >= 1.1.4)
       rack (~> 1.5)
       sinatra (~> 1.4)
+    erubis (2.7.0)
     ns-options (1.1.6)
     rack (1.5.2)
     rack-protection (1.5.3)
@@ -20,3 +21,4 @@ PLATFORMS
 
 DEPENDENCIES
   deas (= 0.25.0)
+  erubis (~> 2.7)

--- a/02_erb_basic/deas-0.25.0/bench_results.txt
+++ b/02_erb_basic/deas-0.25.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    33.98ms   23.82ms  80.50ms   74.55%
-    Req/Sec   172.36     72.42   276.00     60.00%
-  687 requests in 2.00s, 227.59KB read
+    Latency    31.18ms   22.28ms  74.77ms   77.55%
+    Req/Sec   183.55     83.02   288.00     61.22%
+  728 requests in 2.00s, 240.85KB read
   Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    343.47
-Transfer/sec:    113.79KB
+Requests/sec:    363.82
+Transfer/sec:    120.36KB

--- a/02_erb_basic/deas-0.25.0/config.ru
+++ b/02_erb_basic/deas-0.25.0/config.ru
@@ -1,6 +1,8 @@
 require 'rubygems'
 require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+
 require 'deas'
+require 'erubis'
 
 class App
   include Deas::Server

--- a/02_erb_basic/deas-0.27.0/Gemfile
+++ b/02_erb_basic/deas-0.27.0/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
 gem "deas", "= 0.27.0"
+gem "erubis",  "~> 2.7"

--- a/02_erb_basic/deas-0.27.0/Gemfile.lock
+++ b/02_erb_basic/deas-0.27.0/Gemfile.lock
@@ -5,6 +5,7 @@ GEM
       ns-options (~> 1.1, >= 1.1.4)
       rack (~> 1.5)
       sinatra (~> 1.4)
+    erubis (2.7.0)
     ns-options (1.1.6)
     rack (1.5.2)
     rack-protection (1.5.3)
@@ -20,3 +21,4 @@ PLATFORMS
 
 DEPENDENCIES
   deas (= 0.27.0)
+  erubis (~> 2.7)

--- a/02_erb_basic/deas-0.27.0/bench_results.txt
+++ b/02_erb_basic/deas-0.27.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    31.91ms   22.51ms  75.90ms   77.36%
-    Req/Sec   174.70     88.35   306.00     62.26%
-  701 requests in 2.00s, 231.94KB read
-  Socket errors: connect 0, read 8, write 0, timeout 0
-Requests/sec:    350.36
-Transfer/sec:    115.92KB
+    Latency    30.89ms   22.61ms  79.36ms   78.43%
+    Req/Sec   180.67     89.09   297.00     56.86%
+  714 requests in 2.00s, 235.68KB read
+  Socket errors: connect 0, read 7, write 0, timeout 0
+Requests/sec:    356.80
+Transfer/sec:    117.77KB

--- a/02_erb_basic/deas-0.27.0/config.ru
+++ b/02_erb_basic/deas-0.27.0/config.ru
@@ -1,6 +1,8 @@
 require 'rubygems'
 require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+
 require 'deas'
+require 'erubis'
 
 class App
   include Deas::Server

--- a/02_erb_basic/deas-0.28.0/Gemfile
+++ b/02_erb_basic/deas-0.28.0/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
 gem "deas", "= 0.28.0"
+gem "erubis",  "~> 2.7"

--- a/02_erb_basic/deas-0.28.0/Gemfile.lock
+++ b/02_erb_basic/deas-0.28.0/Gemfile.lock
@@ -5,6 +5,7 @@ GEM
       ns-options (~> 1.1, >= 1.1.4)
       rack (~> 1.5)
       sinatra (~> 1.4)
+    erubis (2.7.0)
     ns-options (1.1.6)
     rack (1.5.2)
     rack-protection (1.5.3)
@@ -20,3 +21,4 @@ PLATFORMS
 
 DEPENDENCIES
   deas (= 0.28.0)
+  erubis (~> 2.7)

--- a/02_erb_basic/deas-0.28.0/bench_results.txt
+++ b/02_erb_basic/deas-0.28.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    34.41ms   22.80ms  76.27ms   75.00%
-    Req/Sec   170.12     70.99   263.00     66.67%
-  669 requests in 2.00s, 221.37KB read
-  Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    334.31
-Transfer/sec:    110.62KB
+    Latency    31.10ms   22.34ms  80.71ms   80.39%
+    Req/Sec   174.27     79.78   263.00     66.67%
+  694 requests in 2.00s, 229.35KB read
+  Socket errors: connect 0, read 8, write 0, timeout 0
+Requests/sec:    346.80
+Transfer/sec:    114.61KB

--- a/02_erb_basic/deas-0.28.0/config.ru
+++ b/02_erb_basic/deas-0.28.0/config.ru
@@ -1,6 +1,8 @@
 require 'rubygems'
 require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+
 require 'deas'
+require 'erubis'
 
 class App
   include Deas::Server

--- a/02_erb_basic/sinatra-1.4.5/Gemfile
+++ b/02_erb_basic/sinatra-1.4.5/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
 gem "sinatra", "= 1.4.5"
+gem "erubis",  "~> 2.7"

--- a/02_erb_basic/sinatra-1.4.5/Gemfile.lock
+++ b/02_erb_basic/sinatra-1.4.5/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    erubis (2.7.0)
     rack (1.5.2)
     rack-protection (1.5.3)
       rack
@@ -14,4 +15,5 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  erubis (~> 2.7)
   sinatra (= 1.4.5)

--- a/02_erb_basic/sinatra-1.4.5/bench_results.txt
+++ b/02_erb_basic/sinatra-1.4.5/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    39.22ms   26.29ms  82.05ms   67.24%
-    Req/Sec   168.28     86.67   291.00     72.41%
-  690 requests in 2.05s, 227.75KB read
-  Socket errors: connect 0, read 5, write 0, timeout 0
-Requests/sec:    336.07
-Transfer/sec:    110.93KB
+    Latency    31.84ms   23.28ms  77.64ms   76.19%
+    Req/Sec   188.74     75.70   297.00     54.76%
+  759 requests in 2.00s, 250.53KB read
+  Socket errors: connect 0, read 4, write 0, timeout 0
+Requests/sec:    379.54
+Transfer/sec:    125.28KB

--- a/02_erb_basic/sinatra-1.4.5/config.ru
+++ b/02_erb_basic/sinatra-1.4.5/config.ru
@@ -2,6 +2,7 @@ require 'rubygems'
 require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
 
 require 'sinatra/base'
+require 'erubis'
 
 class App < Sinatra::Application
 

--- a/03_erb_partial/deas-0.25.0/Gemfile
+++ b/03_erb_partial/deas-0.25.0/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
-gem "deas", "= 0.25.0"
+gem "deas",   "= 0.25.0"
+gem "erubis", "~> 2.7"

--- a/03_erb_partial/deas-0.25.0/Gemfile.lock
+++ b/03_erb_partial/deas-0.25.0/Gemfile.lock
@@ -5,6 +5,7 @@ GEM
       ns-options (~> 1.1, >= 1.1.4)
       rack (~> 1.5)
       sinatra (~> 1.4)
+    erubis (2.7.0)
     ns-options (1.1.6)
     rack (1.5.2)
     rack-protection (1.5.3)
@@ -20,3 +21,4 @@ PLATFORMS
 
 DEPENDENCIES
   deas (= 0.25.0)
+  erubis (~> 2.7)

--- a/03_erb_partial/deas-0.25.0/bench_results.txt
+++ b/03_erb_partial/deas-0.25.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    25.37ms   12.00ms  80.56ms   95.83%
-    Req/Sec   153.25     36.34   214.00     54.17%
-  620 requests in 2.00s, 234.59KB read
-  Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    309.91
-Transfer/sec:    117.26KB
+    Latency    34.76ms   25.75ms  88.51ms   77.14%
+    Req/Sec   160.69     81.14   250.00     60.00%
+  642 requests in 2.00s, 243.26KB read
+  Socket errors: connect 0, read 7, write 0, timeout 0
+Requests/sec:    320.87
+Transfer/sec:    121.58KB

--- a/03_erb_partial/deas-0.25.0/config.ru
+++ b/03_erb_partial/deas-0.25.0/config.ru
@@ -1,6 +1,8 @@
 require 'rubygems'
 require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+
 require 'deas'
+require 'erubis'
 
 class App
   include Deas::Server

--- a/03_erb_partial/deas-0.27.0/Gemfile
+++ b/03_erb_partial/deas-0.27.0/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
-gem "deas", "= 0.27.0"
+gem "deas",   "= 0.27.0"
+gem "erubis", "~> 2.7"

--- a/03_erb_partial/deas-0.27.0/Gemfile.lock
+++ b/03_erb_partial/deas-0.27.0/Gemfile.lock
@@ -5,6 +5,7 @@ GEM
       ns-options (~> 1.1, >= 1.1.4)
       rack (~> 1.5)
       sinatra (~> 1.4)
+    erubis (2.7.0)
     ns-options (1.1.6)
     rack (1.5.2)
     rack-protection (1.5.3)
@@ -20,3 +21,4 @@ PLATFORMS
 
 DEPENDENCIES
   deas (= 0.27.0)
+  erubis (~> 2.7)

--- a/03_erb_partial/deas-0.27.0/bench_results.txt
+++ b/03_erb_partial/deas-0.27.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    32.59ms   21.31ms  79.76ms   81.82%
-    Req/Sec   153.86     29.33   225.00     68.18%
-  610 requests in 2.00s, 230.54KB read
-  Socket errors: connect 0, read 5, write 0, timeout 0
-Requests/sec:    304.84
-Transfer/sec:    115.21KB
+    Latency    37.75ms   24.68ms  82.63ms   72.73%
+    Req/Sec   157.27     56.93   246.00     60.61%
+  622 requests in 2.00s, 236.51KB read
+  Socket errors: connect 0, read 4, write 0, timeout 0
+Requests/sec:    310.76
+Transfer/sec:    118.16KB

--- a/03_erb_partial/deas-0.27.0/config.ru
+++ b/03_erb_partial/deas-0.27.0/config.ru
@@ -1,6 +1,8 @@
 require 'rubygems'
 require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+
 require 'deas'
+require 'erubis'
 
 class App
   include Deas::Server

--- a/03_erb_partial/deas-0.28.0/Gemfile
+++ b/03_erb_partial/deas-0.28.0/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
-gem "deas", "= 0.28.0"
+gem "deas",   "= 0.28.0"
+gem "erubis", "~> 2.7"

--- a/03_erb_partial/deas-0.28.0/Gemfile.lock
+++ b/03_erb_partial/deas-0.28.0/Gemfile.lock
@@ -5,6 +5,7 @@ GEM
       ns-options (~> 1.1, >= 1.1.4)
       rack (~> 1.5)
       sinatra (~> 1.4)
+    erubis (2.7.0)
     ns-options (1.1.6)
     rack (1.5.2)
     rack-protection (1.5.3)
@@ -20,3 +21,4 @@ PLATFORMS
 
 DEPENDENCIES
   deas (= 0.28.0)
+  erubis (~> 2.7)

--- a/03_erb_partial/deas-0.28.0/bench_results.txt
+++ b/03_erb_partial/deas-0.28.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    32.48ms   19.76ms  75.02ms   82.61%
-    Req/Sec   148.87     28.09   203.00     65.22%
-  601 requests in 2.00s, 227.41KB read
+    Latency    28.05ms   17.42ms  82.88ms   90.91%
+    Req/Sec   156.32     34.69   226.00     59.09%
+  624 requests in 2.00s, 236.99KB read
   Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    300.33
-Transfer/sec:    113.64KB
+Requests/sec:    311.86
+Transfer/sec:    118.44KB

--- a/03_erb_partial/deas-0.28.0/config.ru
+++ b/03_erb_partial/deas-0.28.0/config.ru
@@ -1,6 +1,8 @@
 require 'rubygems'
 require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+
 require 'deas'
+require 'erubis'
 
 class App
   include Deas::Server

--- a/03_erb_partial/sinatra-1.4.5/Gemfile
+++ b/03_erb_partial/sinatra-1.4.5/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
 gem "sinatra", "= 1.4.5"
+gem "erubis",  "~> 2.7"

--- a/03_erb_partial/sinatra-1.4.5/Gemfile.lock
+++ b/03_erb_partial/sinatra-1.4.5/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    erubis (2.7.0)
     rack (1.5.2)
     rack-protection (1.5.3)
       rack
@@ -14,4 +15,5 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  erubis (~> 2.7)
   sinatra (= 1.4.5)

--- a/03_erb_partial/sinatra-1.4.5/bench_results.txt
+++ b/03_erb_partial/sinatra-1.4.5/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    33.05ms   20.59ms  76.92ms   81.82%
-    Req/Sec   150.36     26.09   201.00     68.18%
-  613 requests in 2.00s, 231.95KB read
-  Socket errors: connect 0, read 5, write 0, timeout 0
-Requests/sec:    306.22
-Transfer/sec:    115.87KB
+    Latency    32.45ms   22.95ms  81.91ms   80.00%
+    Req/Sec   164.13     52.40   246.00     70.00%
+  653 requests in 2.00s, 247.98KB read
+  Socket errors: connect 0, read 4, write 0, timeout 0
+Requests/sec:    326.50
+Transfer/sec:    123.99KB

--- a/03_erb_partial/sinatra-1.4.5/config.ru
+++ b/03_erb_partial/sinatra-1.4.5/config.ru
@@ -2,6 +2,7 @@ require 'rubygems'
 require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
 
 require 'sinatra/base'
+require 'erubis'
 
 class App < Sinatra::Application
 

--- a/04_erb_layout/deas-0.25.0/Gemfile
+++ b/04_erb_layout/deas-0.25.0/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
-gem "deas", "= 0.25.0"
+gem "deas",   "= 0.25.0"
+gem "erubis", "~> 2.7"

--- a/04_erb_layout/deas-0.25.0/Gemfile.lock
+++ b/04_erb_layout/deas-0.25.0/Gemfile.lock
@@ -5,6 +5,7 @@ GEM
       ns-options (~> 1.1, >= 1.1.4)
       rack (~> 1.5)
       sinatra (~> 1.4)
+    erubis (2.7.0)
     ns-options (1.1.6)
     rack (1.5.2)
     rack-protection (1.5.3)
@@ -20,3 +21,4 @@ PLATFORMS
 
 DEPENDENCIES
   deas (= 0.25.0)
+  erubis (~> 2.7)

--- a/04_erb_layout/deas-0.25.0/bench_results.txt
+++ b/04_erb_layout/deas-0.25.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    38.64ms   25.30ms  80.12ms   70.27%
-    Req/Sec   155.05     62.41   254.00     64.86%
-  616 requests in 2.00s, 227.01KB read
-  Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    307.90
-Transfer/sec:    113.47KB
+    Latency    36.86ms   25.15ms  82.14ms   72.50%
+    Req/Sec   161.38     64.46   243.00     57.50%
+  635 requests in 2.00s, 233.44KB read
+  Socket errors: connect 0, read 7, write 0, timeout 0
+Requests/sec:    317.35
+Transfer/sec:    116.66KB

--- a/04_erb_layout/deas-0.25.0/config.ru
+++ b/04_erb_layout/deas-0.25.0/config.ru
@@ -1,6 +1,8 @@
 require 'rubygems'
 require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+
 require 'deas'
+require 'erubis'
 
 class App
   include Deas::Server

--- a/04_erb_layout/deas-0.27.0/Gemfile
+++ b/04_erb_layout/deas-0.27.0/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
-gem "deas", "= 0.27.0"
+gem "deas",   "= 0.27.0"
+gem "erubis", "~> 2.7"

--- a/04_erb_layout/deas-0.27.0/Gemfile.lock
+++ b/04_erb_layout/deas-0.27.0/Gemfile.lock
@@ -5,6 +5,7 @@ GEM
       ns-options (~> 1.1, >= 1.1.4)
       rack (~> 1.5)
       sinatra (~> 1.4)
+    erubis (2.7.0)
     ns-options (1.1.6)
     rack (1.5.2)
     rack-protection (1.5.3)
@@ -20,3 +21,4 @@ PLATFORMS
 
 DEPENDENCIES
   deas (= 0.27.0)
+  erubis (~> 2.7)

--- a/04_erb_layout/deas-0.27.0/bench_results.txt
+++ b/04_erb_layout/deas-0.27.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    37.05ms   24.57ms  77.27ms   72.73%
-    Req/Sec   157.09     33.11   220.00     68.18%
-  618 requests in 2.00s, 227.20KB read
-  Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    308.91
-Transfer/sec:    113.57KB
+    Latency    35.54ms   24.84ms  81.23ms   75.00%
+    Req/Sec   158.55     64.45   253.00     54.55%
+  633 requests in 2.00s, 232.98KB read
+  Socket errors: connect 0, read 7, write 0, timeout 0
+Requests/sec:    316.25
+Transfer/sec:    116.40KB

--- a/04_erb_layout/deas-0.27.0/config.ru
+++ b/04_erb_layout/deas-0.27.0/config.ru
@@ -1,6 +1,8 @@
 require 'rubygems'
 require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+
 require 'deas'
+require 'erubis'
 
 class App
   include Deas::Server

--- a/04_erb_layout/deas-0.28.0/Gemfile
+++ b/04_erb_layout/deas-0.28.0/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
-gem "deas", "= 0.28.0"
+gem "deas",   "= 0.28.0"
+gem "erubis", "~> 2.7"

--- a/04_erb_layout/deas-0.28.0/Gemfile.lock
+++ b/04_erb_layout/deas-0.28.0/Gemfile.lock
@@ -5,6 +5,7 @@ GEM
       ns-options (~> 1.1, >= 1.1.4)
       rack (~> 1.5)
       sinatra (~> 1.4)
+    erubis (2.7.0)
     ns-options (1.1.6)
     rack (1.5.2)
     rack-protection (1.5.3)
@@ -20,3 +21,4 @@ PLATFORMS
 
 DEPENDENCIES
   deas (= 0.28.0)
+  erubis (~> 2.7)

--- a/04_erb_layout/deas-0.28.0/bench_results.txt
+++ b/04_erb_layout/deas-0.28.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    30.39ms   19.94ms  77.20ms   85.00%
-    Req/Sec   155.40     29.27   211.00     60.00%
-  614 requests in 2.00s, 226.55KB read
-  Socket errors: connect 0, read 6, write 0, timeout 0
-Requests/sec:    306.91
-Transfer/sec:    113.25KB
+    Latency    26.36ms   16.95ms  81.07ms   90.91%
+    Req/Sec   156.00     30.59   221.00     63.64%
+  627 requests in 2.00s, 231.33KB read
+  Socket errors: connect 0, read 4, write 0, timeout 0
+Requests/sec:    313.51
+Transfer/sec:    115.67KB

--- a/04_erb_layout/deas-0.28.0/config.ru
+++ b/04_erb_layout/deas-0.28.0/config.ru
@@ -1,6 +1,8 @@
 require 'rubygems'
 require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+
 require 'deas'
+require 'erubis'
 
 class App
   include Deas::Server

--- a/04_erb_layout/sinatra-1.4.5/Gemfile
+++ b/04_erb_layout/sinatra-1.4.5/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
 gem "sinatra", "= 1.4.5"
+gem "erubis",  "~> 2.7"

--- a/04_erb_layout/sinatra-1.4.5/Gemfile.lock
+++ b/04_erb_layout/sinatra-1.4.5/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    erubis (2.7.0)
     rack (1.5.2)
     rack-protection (1.5.3)
       rack
@@ -14,4 +15,5 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  erubis (~> 2.7)
   sinatra (= 1.4.5)

--- a/04_erb_layout/sinatra-1.4.5/bench_results.txt
+++ b/04_erb_layout/sinatra-1.4.5/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    38.47ms   23.41ms  77.36ms   73.68%
-    Req/Sec   144.47     15.69   176.00     68.42%
-  582 requests in 2.00s, 213.70KB read
-  Socket errors: connect 0, read 3, write 0, timeout 0
-Requests/sec:    290.96
-Transfer/sec:    106.84KB
+    Latency    34.70ms   23.83ms  82.23ms   76.74%
+    Req/Sec   160.44     77.23   250.00     67.44%
+  654 requests in 2.00s, 240.69KB read
+  Socket errors: connect 0, read 4, write 0, timeout 0
+Requests/sec:    326.92
+Transfer/sec:    120.32KB

--- a/04_erb_layout/sinatra-1.4.5/config.ru
+++ b/04_erb_layout/sinatra-1.4.5/config.ru
@@ -2,6 +2,7 @@ require 'rubygems'
 require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
 
 require 'sinatra/base'
+require 'erubis'
 
 class App < Sinatra::Application
 

--- a/05_erb_layout_partial/deas-0.25.0/Gemfile
+++ b/05_erb_layout_partial/deas-0.25.0/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
-gem "deas", "= 0.25.0"
+gem "deas",   "= 0.25.0"
+gem "erubis", "~> 2.7"

--- a/05_erb_layout_partial/deas-0.25.0/Gemfile.lock
+++ b/05_erb_layout_partial/deas-0.25.0/Gemfile.lock
@@ -5,6 +5,7 @@ GEM
       ns-options (~> 1.1, >= 1.1.4)
       rack (~> 1.5)
       sinatra (~> 1.4)
+    erubis (2.7.0)
     ns-options (1.1.6)
     rack (1.5.2)
     rack-protection (1.5.3)
@@ -20,3 +21,4 @@ PLATFORMS
 
 DEPENDENCIES
   deas (= 0.25.0)
+  erubis (~> 2.7)

--- a/05_erb_layout_partial/deas-0.25.0/bench_results.txt
+++ b/05_erb_layout_partial/deas-0.25.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    38.35ms   24.81ms  79.75ms   72.73%
-    Req/Sec   140.73     24.15   181.00     59.09%
-  568 requests in 2.00s, 232.69KB read
+    Latency    40.72ms   25.47ms  82.04ms   70.00%
+    Req/Sec   144.20     19.98   185.00     65.00%
+  571 requests in 2.00s, 234.19KB read
   Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    283.93
-Transfer/sec:    116.32KB
+Requests/sec:    285.43
+Transfer/sec:    117.07KB

--- a/05_erb_layout_partial/deas-0.25.0/config.ru
+++ b/05_erb_layout_partial/deas-0.25.0/config.ru
@@ -1,6 +1,8 @@
 require 'rubygems'
 require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+
 require 'deas'
+require 'erubis'
 
 class App
   include Deas::Server

--- a/05_erb_layout_partial/deas-0.27.0/Gemfile
+++ b/05_erb_layout_partial/deas-0.27.0/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
-gem "deas", "= 0.27.0"
+gem "deas",   "= 0.27.0"
+gem "erubis", "~> 2.7"

--- a/05_erb_layout_partial/deas-0.27.0/Gemfile.lock
+++ b/05_erb_layout_partial/deas-0.27.0/Gemfile.lock
@@ -5,6 +5,7 @@ GEM
       ns-options (~> 1.1, >= 1.1.4)
       rack (~> 1.5)
       sinatra (~> 1.4)
+    erubis (2.7.0)
     ns-options (1.1.6)
     rack (1.5.2)
     rack-protection (1.5.3)
@@ -20,3 +21,4 @@ PLATFORMS
 
 DEPENDENCIES
   deas (= 0.27.0)
+  erubis (~> 2.7)

--- a/05_erb_layout_partial/deas-0.27.0/bench_results.txt
+++ b/05_erb_layout_partial/deas-0.27.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    43.94ms   26.96ms  82.75ms   63.64%
-    Req/Sec   144.23     31.65   203.00     54.55%
-  576 requests in 2.00s, 235.40KB read
-  Socket errors: connect 0, read 5, write 0, timeout 0
-Requests/sec:    287.72
-Transfer/sec:    117.59KB
+    Latency    25.97ms   12.19ms  80.30ms   95.45%
+    Req/Sec   141.59     27.25   208.00     81.82%
+  570 requests in 2.02s, 233.51KB read
+  Socket errors: connect 0, read 3, write 1, timeout 0
+Requests/sec:    281.76
+Transfer/sec:    115.43KB

--- a/05_erb_layout_partial/deas-0.27.0/config.ru
+++ b/05_erb_layout_partial/deas-0.27.0/config.ru
@@ -1,6 +1,8 @@
 require 'rubygems'
 require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+
 require 'deas'
+require 'erubis'
 
 class App
   include Deas::Server

--- a/05_erb_layout_partial/deas-0.28.0/Gemfile
+++ b/05_erb_layout_partial/deas-0.28.0/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
-gem "deas", "= 0.28.0"
+gem "deas",   "= 0.28.0"
+gem "erubis", "~> 2.7"

--- a/05_erb_layout_partial/deas-0.28.0/Gemfile.lock
+++ b/05_erb_layout_partial/deas-0.28.0/Gemfile.lock
@@ -5,6 +5,7 @@ GEM
       ns-options (~> 1.1, >= 1.1.4)
       rack (~> 1.5)
       sinatra (~> 1.4)
+    erubis (2.7.0)
     ns-options (1.1.6)
     rack (1.5.2)
     rack-protection (1.5.3)
@@ -20,3 +21,4 @@ PLATFORMS
 
 DEPENDENCIES
   deas (= 0.28.0)
+  erubis (~> 2.7)

--- a/05_erb_layout_partial/deas-0.28.0/bench_results.txt
+++ b/05_erb_layout_partial/deas-0.28.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    37.17ms   23.44ms  84.93ms   80.00%
-    Req/Sec   137.00     29.13   195.00     75.00%
-  550 requests in 2.00s, 225.06KB read
-  Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    274.88
-Transfer/sec:    112.48KB
+    Latency    37.73ms   23.86ms  85.54ms   77.27%
+    Req/Sec   138.91     29.99   193.00     72.73%
+  567 requests in 2.00s, 232.83KB read
+  Socket errors: connect 0, read 6, write 1, timeout 0
+Requests/sec:    283.48
+Transfer/sec:    116.41KB

--- a/05_erb_layout_partial/deas-0.28.0/config.ru
+++ b/05_erb_layout_partial/deas-0.28.0/config.ru
@@ -1,6 +1,8 @@
 require 'rubygems'
 require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+
 require 'deas'
+require 'erubis'
 
 class App
   include Deas::Server

--- a/05_erb_layout_partial/sinatra-1.4.5/Gemfile
+++ b/05_erb_layout_partial/sinatra-1.4.5/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
 gem "sinatra", "= 1.4.5"
+gem "erubis",  "~> 2.7"

--- a/05_erb_layout_partial/sinatra-1.4.5/Gemfile.lock
+++ b/05_erb_layout_partial/sinatra-1.4.5/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    erubis (2.7.0)
     rack (1.5.2)
     rack-protection (1.5.3)
       rack
@@ -14,4 +15,5 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  erubis (~> 2.7)
   sinatra (= 1.4.5)

--- a/05_erb_layout_partial/sinatra-1.4.5/bench_results.txt
+++ b/05_erb_layout_partial/sinatra-1.4.5/bench_results.txt
@@ -1,8 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    41.37ms   25.59ms  84.27ms   70.00%
-    Req/Sec   136.65     20.46   193.00     65.00%
-  554 requests in 2.00s, 226.14KB read
-Requests/sec:    276.88
-Transfer/sec:    113.02KB
+    Latency    36.73ms   25.29ms  80.81ms   72.73%
+    Req/Sec   160.57     89.94   273.00     70.45%
+  640 requests in 2.00s, 261.88KB read
+  Socket errors: connect 0, read 7, write 0, timeout 0
+Requests/sec:    319.66
+Transfer/sec:    130.80KB

--- a/05_erb_layout_partial/sinatra-1.4.5/config.ru
+++ b/05_erb_layout_partial/sinatra-1.4.5/config.ru
@@ -2,6 +2,7 @@ require 'rubygems'
 require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
 
 require 'sinatra/base'
+require 'erubis'
 
 class App < Sinatra::Application
 

--- a/06_hello_many_routes/deas-0.25.0/bench_results.txt
+++ b/06_hello_many_routes/deas-0.25.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    33.52ms   22.15ms  82.00ms   80.00%
-    Req/Sec   161.48     41.25   234.00     60.00%
-  642 requests in 2.00s, 180.76KB read
-  Socket errors: connect 0, read 3, write 0, timeout 0
-Requests/sec:    320.90
-Transfer/sec:     90.35KB
+    Latency    36.88ms   24.07ms  84.05ms   73.08%
+    Req/Sec   157.12     42.21   222.00     50.00%
+  635 requests in 2.00s, 177.97KB read
+  Socket errors: connect 0, read 4, write 0, timeout 0
+Requests/sec:    317.39
+Transfer/sec:     88.95KB

--- a/06_hello_many_routes/deas-0.27.0/bench_results.txt
+++ b/06_hello_many_routes/deas-0.27.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    26.84ms   14.52ms  77.28ms   92.00%
-    Req/Sec   159.16     38.64   224.00     64.00%
-  636 requests in 2.00s, 178.25KB read
+    Latency    35.92ms   21.92ms  78.51ms   76.92%
+    Req/Sec   153.54     36.85   219.00     50.00%
+  618 requests in 2.00s, 173.76KB read
   Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    317.92
-Transfer/sec:     89.10KB
+Requests/sec:    308.99
+Transfer/sec:     86.88KB

--- a/06_hello_many_routes/deas-0.28.0/bench_results.txt
+++ b/06_hello_many_routes/deas-0.28.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    42.09ms   26.04ms  83.44ms   65.38%
-    Req/Sec   157.73     43.16   231.00     46.15%
-  629 requests in 2.00s, 176.57KB read
-  Socket errors: connect 0, read 5, write 1, timeout 0
-Requests/sec:    314.42
-Transfer/sec:     88.26KB
+    Latency    25.80ms   10.75ms  75.69ms   95.83%
+    Req/Sec   153.92     38.68   231.00     75.00%
+  618 requests in 2.00s, 173.48KB read
+  Socket errors: connect 0, read 4, write 0, timeout 0
+Requests/sec:    308.93
+Transfer/sec:     86.72KB

--- a/06_hello_many_routes/sinatra-1.4.5/bench_results.txt
+++ b/06_hello_many_routes/sinatra-1.4.5/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    39.16ms   24.85ms  76.38ms   66.67%
-    Req/Sec   166.29     29.93   221.00     71.43%
-  660 requests in 2.00s, 185.53KB read
-  Socket errors: connect 0, read 5, write 0, timeout 0
-Requests/sec:    329.87
-Transfer/sec:     92.73KB
+    Latency    29.64ms   17.83ms  74.26ms   86.36%
+    Req/Sec   160.95     36.37   233.00     68.18%
+  639 requests in 2.00s, 179.64KB read
+  Socket errors: connect 0, read 6, write 0, timeout 0
+Requests/sec:    319.35
+Transfer/sec:     89.78KB

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Single "Hello World" endpoint
 
 |    Version    | Requests/sec | Transfer/sec |
 | ------------- | ------------ | ------------ |
-| sinatra-1.4.5 |       454.33 |     127.61KB |
-|   deas-0.25.0 |       422.50 |     118.55KB |
-|   deas-0.27.0 |       430.40 |     120.90KB |
-|   deas-0.28.0 |       432.93 |     121.75KB |
+|   deas-0.28.0 |       428.91 |     120.49KB |
+|   deas-0.27.0 |       419.98 |     117.85KB |
+|   deas-0.25.0 |       424.93 |     119.51KB |
+| sinatra-1.4.5 |       452.88 |     127.07KB |
 
 ### 02_erb_basic
 
@@ -21,10 +21,10 @@ Single endpoint rendering with no partials or layouts.
 
 |    Version    | Requests/sec | Transfer/sec |
 | ------------- | ------------ | ------------ |
-| sinatra-1.4.5 |       336.07 |     110.93KB |
-|   deas-0.25.0 |       343.47 |     113.79KB |
-|   deas-0.27.0 |       350.36 |     115.92KB |
-|   deas-0.28.0 |       334.31 |     110.62KB |
+|   deas-0.28.0 |       346.80 |     114.61KB |
+|   deas-0.27.0 |       356.80 |     117.77KB |
+|   deas-0.25.0 |       363.82 |     120.36KB |
+| sinatra-1.4.5 |       379.54 |     125.28KB |
 
 ### 03_erb_partial
 
@@ -32,10 +32,10 @@ Single endpoint rendering a partial with no layout.
 
 |    Version    | Requests/sec | Transfer/sec |
 | ------------- | ------------ | ------------ |
-| sinatra-1.4.5 |       306.22 |     115.87KB |
-|   deas-0.25.0 |       309.91 |     117.26KB |
-|   deas-0.27.0 |       304.84 |     115.21KB |
-|   deas-0.28.0 |       300.33 |     113.64KB |
+|   deas-0.28.0 |       311.86 |     118.44KB |
+|   deas-0.27.0 |       310.76 |     118.16KB |
+|   deas-0.25.0 |       320.87 |     121.58KB |
+| sinatra-1.4.5 |       326.50 |     123.99KB |
 
 ### 04_erb_layout
 
@@ -43,10 +43,10 @@ Single endpoint rendering in a layout.
 
 |    Version    | Requests/sec | Transfer/sec |
 | ------------- | ------------ | ------------ |
-| sinatra-1.4.5 |       290.96 |     106.84KB |
-|   deas-0.25.0 |       307.90 |     113.47KB |
-|   deas-0.27.0 |       308.91 |     113.57KB |
-|   deas-0.28.0 |       306.91 |     113.25KB |
+|   deas-0.28.0 |       313.51 |     115.67KB |
+|   deas-0.27.0 |       316.25 |     116.40KB |
+|   deas-0.25.0 |       317.35 |     116.66KB |
+| sinatra-1.4.5 |       326.92 |     120.32KB |
 
 ### 05_erb_layout_partial
 
@@ -54,10 +54,10 @@ Single endpoint rendering a partial in a layout.
 
 |    Version    | Requests/sec | Transfer/sec |
 | ------------- | ------------ | ------------ |
-| sinatra-1.4.5 |       276.88 |     113.02KB |
-|   deas-0.25.0 |       283.93 |     116.32KB |
-|   deas-0.27.0 |       287.72 |     117.59KB |
-|   deas-0.28.0 |       274.88 |     112.48KB |
+|   deas-0.28.0 |       283.48 |     116.41KB |
+|   deas-0.27.0 |       281.76 |     115.43KB |
+|   deas-0.25.0 |       285.43 |     117.07KB |
+| sinatra-1.4.5 |       319.66 |     130.80KB |
 
 ### 06_hello_many_routes
 
@@ -65,10 +65,10 @@ Single endpoint rendering a partial in a layout.
 
 |    Version    | Requests/sec | Transfer/sec |
 | ------------- | ------------ | ------------ |
-| sinatra-1.4.5 |       329.87 |      92.73KB |
-|   deas-0.25.0 |       320.90 |      90.35KB |
-|   deas-0.27.0 |       317.92 |      89.10KB |
-|   deas-0.28.0 |       314.42 |      88.26KB |
+|   deas-0.28.0 |       308.93 |      86.72KB |
+|   deas-0.27.0 |       308.99 |      86.88KB |
+|   deas-0.25.0 |       317.39 |      88.95KB |
+| sinatra-1.4.5 |       319.35 |      89.78KB |
 
 ## Usage
 

--- a/bench_all
+++ b/bench_all
@@ -64,7 +64,9 @@ CASES = [
 ]
 
 begin
-  puts CASES.map{ |c| DeasBenchCase.new(c).tap(&:run).to_md }.join
+  folder = ARGV.first.to_s.gsub('/', '')
+  cases = folder.empty? ? CASES : CASES.select{ |c| c[:name] == folder }
+  puts cases.map{ |c| DeasBenchCase.new(c).tap(&:run).to_md }.join
 rescue StandardError => exception
   $stderr.puts "#{exception.class}: #{exception.message}"
   $stderr.puts exception.backtrace.join("\n")

--- a/bench_all
+++ b/bench_all
@@ -12,8 +12,8 @@ class DeasBenchCase
     @name = case_data[:name]
     @desc = case_data[:desc]
 
-    @sinatra_dirs = Dir.glob("#{@name}/sinatra-*")
-    @deas_dirs    = Dir.glob("#{@name}/deas-*")
+    @deas_dirs    = Dir.glob("#{@name}/deas-*").reverse
+    @sinatra_dirs = Dir.glob("#{@name}/sinatra-*").reverse
 
     @results = []
   end
@@ -33,7 +33,7 @@ class DeasBenchCase
   def run
     puts @name
 
-    dirs = @sinatra_dirs + @deas_dirs
+    dirs = @deas_dirs + @sinatra_dirs
     cmds = dirs.map do |d|
       { :version => d.split('/').last, :cmd => Scmd.new("#{CMD} #{d}") }
     end


### PR DESCRIPTION
This updates the erb cases to use erubis to render.  This is
so we can bench deas using the new deas-erubis gem and be comparing
apples-to-apples.  This also reruns all the cases with the new
ordering and stats.

@jcredding FYI.