### PR TITLE
Bench using deas v0.29 with deas-erubis v0.3

### DIFF
--- a/01_hello/deas-0.25.0/bench_results.txt
+++ b/01_hello/deas-0.25.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    33.36ms   25.84ms  75.50ms   69.23%
-    Req/Sec   212.89    111.76   371.00     63.08%
-  850 requests in 2.00s, 239.06KB read
-  Socket errors: connect 0, read 2, write 0, timeout 0
-Requests/sec:    424.93
-Transfer/sec:    119.51KB
+    Latency    34.56ms   27.01ms  79.08ms   67.86%
+    Req/Sec   210.29    113.96   371.00     71.43%
+  836 requests in 2.00s, 234.58KB read
+  Socket errors: connect 0, read 7, write 0, timeout 0
+Requests/sec:    417.49
+Transfer/sec:    117.15KB

--- a/01_hello/deas-0.27.0/bench_results.txt
+++ b/01_hello/deas-0.27.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    35.98ms   26.60ms  76.01ms   64.18%
-    Req/Sec   209.79    115.39   348.00     65.67%
-  840 requests in 2.00s, 235.70KB read
-  Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    419.98
-Transfer/sec:    117.85KB
+    Latency    34.44ms   26.73ms  75.42ms   68.92%
+    Req/Sec   203.64    113.59   350.00     70.27%
+  810 requests in 2.00s, 228.12KB read
+  Socket errors: connect 0, read 6, write 0, timeout 0
+Requests/sec:    404.93
+Transfer/sec:    114.04KB

--- a/01_hello/deas-0.28.0/bench_results.txt
+++ b/01_hello/deas-0.28.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    31.79ms   24.61ms  72.95ms   70.89%
-    Req/Sec   219.67    122.70   378.00     65.82%
-  858 requests in 2.00s, 241.02KB read
+    Latency    31.54ms   25.54ms  78.07ms   73.42%
+    Req/Sec   211.23    119.19   368.00     67.09%
+  837 requests in 2.00s, 235.41KB read
   Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    428.91
-Transfer/sec:    120.49KB
+Requests/sec:    418.24
+Transfer/sec:    117.63KB

--- a/01_hello/deas-0.29.0/Gemfile
+++ b/01_hello/deas-0.29.0/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "deas", "= 0.29.0"

--- a/01_hello/deas-0.29.0/Gemfile.lock
+++ b/01_hello/deas-0.29.0/Gemfile.lock
@@ -1,0 +1,22 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    deas (0.29.0)
+      ns-options (~> 1.1, >= 1.1.4)
+      rack (~> 1.5)
+      sinatra (~> 1.4)
+    ns-options (1.1.6)
+    rack (1.5.2)
+    rack-protection (1.5.3)
+      rack
+    sinatra (1.4.5)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
+    tilt (1.4.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  deas (= 0.29.0)

--- a/01_hello/deas-0.29.0/bench_results.txt
+++ b/01_hello/deas-0.29.0/bench_results.txt
@@ -1,0 +1,9 @@
+Running 2s test @ http://0.0.0.0:9292
+  2 threads and 10 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency    30.79ms   25.13ms  76.93ms   74.51%
+    Req/Sec   210.35    109.18   342.00     72.55%
+  835 requests in 2.00s, 234.03KB read
+  Socket errors: connect 0, read 4, write 0, timeout 0
+Requests/sec:    417.44
+Transfer/sec:    117.00KB

--- a/01_hello/deas-0.29.0/config.ru
+++ b/01_hello/deas-0.29.0/config.ru
@@ -1,0 +1,22 @@
+require 'rubygems'
+require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+require 'deas'
+
+class App
+  include Deas::Server
+
+  root File.expand_path('..', __FILE__)
+
+  get '/', 'App::Hello'
+
+  class Hello
+    include Deas::ViewHandler
+
+    def run!
+      'Hello!'
+    end
+  end
+
+end
+
+run App.new

--- a/01_hello/sinatra-1.4.5/bench_results.txt
+++ b/01_hello/sinatra-1.4.5/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    28.61ms   23.19ms  69.72ms   75.00%
-    Req/Sec   230.58    126.16   384.00     69.74%
-  906 requests in 2.00s, 254.20KB read
-  Socket errors: connect 0, read 7, write 0, timeout 0
-Requests/sec:    452.88
-Transfer/sec:    127.07KB
+    Latency    32.18ms   25.74ms  74.86ms   70.27%
+    Req/Sec   221.69    128.79   384.00     64.86%
+  882 requests in 2.00s, 247.75KB read
+  Socket errors: connect 0, read 4, write 0, timeout 0
+Requests/sec:    440.80
+Transfer/sec:    123.82KB

--- a/02_erb_basic/deas-0.25.0/bench_results.txt
+++ b/02_erb_basic/deas-0.25.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    31.18ms   22.28ms  74.77ms   77.55%
-    Req/Sec   183.55     83.02   288.00     61.22%
-  728 requests in 2.00s, 240.85KB read
-  Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    363.82
-Transfer/sec:    120.36KB
+    Latency    37.46ms   26.57ms  84.00ms   70.37%
+    Req/Sec   171.33     85.69   279.00     72.22%
+  696 requests in 2.00s, 230.01KB read
+  Socket errors: connect 0, read 3, write 1, timeout 0
+Requests/sec:    348.03
+Transfer/sec:    115.02KB

--- a/02_erb_basic/deas-0.27.0/bench_results.txt
+++ b/02_erb_basic/deas-0.27.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    30.89ms   22.61ms  79.36ms   78.43%
-    Req/Sec   180.67     89.09   297.00     56.86%
-  714 requests in 2.00s, 235.68KB read
-  Socket errors: connect 0, read 7, write 0, timeout 0
-Requests/sec:    356.80
-Transfer/sec:    117.77KB
+    Latency    30.07ms   21.88ms  80.39ms   82.69%
+    Req/Sec   172.37     89.48   269.00     61.54%
+  697 requests in 2.00s, 230.06KB read
+  Socket errors: connect 0, read 4, write 0, timeout 0
+Requests/sec:    348.29
+Transfer/sec:    114.96KB

--- a/02_erb_basic/deas-0.28.0/bench_results.txt
+++ b/02_erb_basic/deas-0.28.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    31.10ms   22.34ms  80.71ms   80.39%
-    Req/Sec   174.27     79.78   263.00     66.67%
-  694 requests in 2.00s, 229.35KB read
-  Socket errors: connect 0, read 8, write 0, timeout 0
-Requests/sec:    346.80
-Transfer/sec:    114.61KB
+    Latency    39.04ms   26.18ms  84.57ms   70.73%
+    Req/Sec   154.95     73.64   250.00     51.22%
+  646 requests in 2.00s, 213.51KB read
+  Socket errors: connect 0, read 6, write 0, timeout 0
+Requests/sec:    323.01
+Transfer/sec:    106.75KB

--- a/02_erb_basic/deas-0.29.0/Gemfile
+++ b/02_erb_basic/deas-0.29.0/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "deas", "= 0.29.0"
+gem "deas-erubis", "~> 0.3"

--- a/02_erb_basic/deas-0.29.0/Gemfile.lock
+++ b/02_erb_basic/deas-0.29.0/Gemfile.lock
@@ -1,0 +1,27 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    deas (0.29.0)
+      ns-options (~> 1.1, >= 1.1.4)
+      rack (~> 1.5)
+      sinatra (~> 1.4)
+    deas-erubis (0.3.0)
+      deas (~> 0.29)
+      erubis
+    erubis (2.7.0)
+    ns-options (1.1.6)
+    rack (1.5.2)
+    rack-protection (1.5.3)
+      rack
+    sinatra (1.4.5)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
+    tilt (1.4.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  deas (= 0.29.0)
+  deas-erubis (~> 0.3)

--- a/02_erb_basic/deas-0.29.0/basic.html.erb
+++ b/02_erb_basic/deas-0.29.0/basic.html.erb
@@ -1,0 +1,2 @@
+<h1>An Erb Template!</h1>
+<p>Some markup up in here</p>

--- a/02_erb_basic/deas-0.29.0/basic.html.erb.cache
+++ b/02_erb_basic/deas-0.29.0/basic.html.erb.cache
@@ -1,0 +1,3 @@
+@_erb_buf = ''; @_erb_buf << %Q`<h1>An Erb Template!</h1>
+<p>Some markup up in here</p>\n`
+@_erb_buf.to_s

--- a/02_erb_basic/deas-0.29.0/bench_results.txt
+++ b/02_erb_basic/deas-0.29.0/bench_results.txt
@@ -1,0 +1,9 @@
+Running 2s test @ http://0.0.0.0:9292
+  2 threads and 10 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency    31.90ms   23.77ms  76.67ms   77.27%
+    Req/Sec   178.45     37.19   248.00     59.09%
+  713 requests in 2.00s, 235.62KB read
+  Socket errors: connect 0, read 7, write 0, timeout 0
+Requests/sec:    356.52
+Transfer/sec:    117.82KB

--- a/02_erb_basic/deas-0.29.0/config.ru
+++ b/02_erb_basic/deas-0.29.0/config.ru
@@ -1,0 +1,30 @@
+require 'rubygems'
+require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+
+require 'deas'
+require 'deas-erubis'
+
+class App
+  include Deas::Server
+
+  root       File.expand_path('..', __FILE__)
+  views_root File.expand_path('..', __FILE__)
+
+  s = Deas::TemplateSource.new(self.views_root).tap do |s|
+    s.engine('erb', Deas::Erubis::TemplateEngine, 'cache' => true)
+  end
+  template_source s
+
+  get '/', 'App::ErbBasic'
+
+  class ErbBasic
+    include Deas::ViewHandler
+
+    def run!
+      render 'basic.html'
+    end
+  end
+
+end
+
+run App.new

--- a/02_erb_basic/sinatra-1.4.5/bench_results.txt
+++ b/02_erb_basic/sinatra-1.4.5/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    31.84ms   23.28ms  77.64ms   76.19%
-    Req/Sec   188.74     75.70   297.00     54.76%
-  759 requests in 2.00s, 250.53KB read
-  Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    379.54
-Transfer/sec:    125.28KB
+    Latency    31.88ms   23.16ms  76.71ms   77.55%
+    Req/Sec   182.39     78.48   319.00     69.39%
+  734 requests in 2.00s, 242.28KB read
+  Socket errors: connect 0, read 6, write 0, timeout 0
+Requests/sec:    366.94
+Transfer/sec:    121.12KB

--- a/03_erb_partial/deas-0.25.0/bench_results.txt
+++ b/03_erb_partial/deas-0.25.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    34.76ms   25.75ms  88.51ms   77.14%
-    Req/Sec   160.69     81.14   250.00     60.00%
-  642 requests in 2.00s, 243.26KB read
-  Socket errors: connect 0, read 7, write 0, timeout 0
-Requests/sec:    320.87
-Transfer/sec:    121.58KB
+    Latency    35.36ms   23.80ms  82.10ms   78.12%
+    Req/Sec   150.75     64.54   242.00     62.50%
+  616 requests in 2.01s, 233.96KB read
+  Socket errors: connect 0, read 4, write 0, timeout 0
+Requests/sec:    307.21
+Transfer/sec:    116.68KB

--- a/03_erb_partial/deas-0.27.0/bench_results.txt
+++ b/03_erb_partial/deas-0.27.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    37.75ms   24.68ms  82.63ms   72.73%
-    Req/Sec   157.27     56.93   246.00     60.61%
-  622 requests in 2.00s, 236.51KB read
-  Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    310.76
-Transfer/sec:    118.16KB
+    Latency    27.71ms   16.28ms  81.43ms   91.67%
+    Req/Sec   150.88     39.88   229.00     70.83%
+  622 requests in 2.00s, 235.96KB read
+  Socket errors: connect 0, read 6, write 0, timeout 0
+Requests/sec:    310.93
+Transfer/sec:    117.95KB

--- a/03_erb_partial/deas-0.28.0/bench_results.txt
+++ b/03_erb_partial/deas-0.28.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    28.05ms   17.42ms  82.88ms   90.91%
-    Req/Sec   156.32     34.69   226.00     59.09%
-  624 requests in 2.00s, 236.99KB read
-  Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    311.86
-Transfer/sec:    118.44KB
+    Latency    32.04ms   20.44ms  84.32ms   86.36%
+    Req/Sec   140.82     35.40   221.00     72.73%
+  585 requests in 2.00s, 221.94KB read
+  Socket errors: connect 0, read 5, write 0, timeout 0
+Requests/sec:    292.33
+Transfer/sec:    110.90KB

--- a/03_erb_partial/deas-0.29.0/Gemfile
+++ b/03_erb_partial/deas-0.29.0/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "deas", "= 0.29.0"
+gem "deas-erubis", "~> 0.3"

--- a/03_erb_partial/deas-0.29.0/Gemfile.lock
+++ b/03_erb_partial/deas-0.29.0/Gemfile.lock
@@ -1,0 +1,27 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    deas (0.29.0)
+      ns-options (~> 1.1, >= 1.1.4)
+      rack (~> 1.5)
+      sinatra (~> 1.4)
+    deas-erubis (0.3.0)
+      deas (~> 0.29)
+      erubis
+    erubis (2.7.0)
+    ns-options (1.1.6)
+    rack (1.5.2)
+    rack-protection (1.5.3)
+      rack
+    sinatra (1.4.5)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
+    tilt (1.4.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  deas (= 0.29.0)
+  deas-erubis (~> 0.3)

--- a/03_erb_partial/deas-0.29.0/_partial.html.erb
+++ b/03_erb_partial/deas-0.29.0/_partial.html.erb
@@ -1,0 +1,2 @@
+<h2>Some Partial Content</h2>
+<p>up in here</p>

--- a/03_erb_partial/deas-0.29.0/basic_w_partial.html.erb
+++ b/03_erb_partial/deas-0.29.0/basic_w_partial.html.erb
@@ -1,0 +1,3 @@
+<h1>An Erb Template!</h1>
+<p>Some markup up in here</p>
+<%= partial '_partial.html' %>

--- a/03_erb_partial/deas-0.29.0/bench_results.txt
+++ b/03_erb_partial/deas-0.29.0/bench_results.txt
@@ -1,0 +1,9 @@
+Running 2s test @ http://0.0.0.0:9292
+  2 threads and 10 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency    37.64ms   26.14ms  79.27ms   67.65%
+    Req/Sec   172.35     67.91   278.00     47.06%
+  695 requests in 2.00s, 263.62KB read
+  Socket errors: connect 0, read 4, write 0, timeout 0
+Requests/sec:    347.44
+Transfer/sec:    131.79KB

--- a/03_erb_partial/deas-0.29.0/config.ru
+++ b/03_erb_partial/deas-0.29.0/config.ru
@@ -1,0 +1,30 @@
+require 'rubygems'
+require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+
+require 'deas'
+require 'deas-erubis'
+
+class App
+  include Deas::Server
+
+  root       File.expand_path('..', __FILE__)
+  views_root File.expand_path('..', __FILE__)
+
+  s = Deas::TemplateSource.new(self.views_root).tap do |s|
+    s.engine('erb', Deas::Erubis::TemplateEngine, 'cache' => true)
+  end
+  template_source s
+
+  get '/', 'App::ErbPartial'
+
+  class ErbPartial
+    include Deas::ViewHandler
+
+    def run!
+      render 'basic_w_partial.html'
+    end
+  end
+
+end
+
+run App.new

--- a/03_erb_partial/sinatra-1.4.5/bench_results.txt
+++ b/03_erb_partial/sinatra-1.4.5/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    32.45ms   22.95ms  81.91ms   80.00%
-    Req/Sec   164.13     52.40   246.00     70.00%
-  653 requests in 2.00s, 247.98KB read
+    Latency    28.95ms   18.55ms  77.32ms   87.10%
+    Req/Sec   163.42     52.82   246.00     67.74%
+  645 requests in 2.00s, 244.67KB read
   Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    326.50
-Transfer/sec:    123.99KB
+Requests/sec:    322.33
+Transfer/sec:    122.27KB

--- a/04_erb_layout/deas-0.25.0/bench_results.txt
+++ b/04_erb_layout/deas-0.25.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    36.86ms   25.15ms  82.14ms   72.50%
-    Req/Sec   161.38     64.46   243.00     57.50%
-  635 requests in 2.00s, 233.44KB read
+    Latency    35.69ms   24.71ms  80.56ms   75.00%
+    Req/Sec   162.28     56.43   250.00     68.75%
+  636 requests in 2.00s, 234.36KB read
   Socket errors: connect 0, read 7, write 0, timeout 0
-Requests/sec:    317.35
-Transfer/sec:    116.66KB
+Requests/sec:    317.88
+Transfer/sec:    117.13KB

--- a/04_erb_layout/deas-0.27.0/bench_results.txt
+++ b/04_erb_layout/deas-0.27.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    35.54ms   24.84ms  81.23ms   75.00%
-    Req/Sec   158.55     64.45   253.00     54.55%
-  633 requests in 2.00s, 232.98KB read
-  Socket errors: connect 0, read 7, write 0, timeout 0
-Requests/sec:    316.25
-Transfer/sec:    116.40KB
+    Latency    35.49ms   24.93ms  81.24ms   75.00%
+    Req/Sec   152.35     28.03   204.00     60.00%
+  633 requests in 2.00s, 233.26KB read
+  Socket errors: connect 0, read 4, write 0, timeout 0
+Requests/sec:    316.45
+Transfer/sec:    116.61KB

--- a/04_erb_layout/deas-0.28.0/bench_results.txt
+++ b/04_erb_layout/deas-0.28.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    26.36ms   16.95ms  81.07ms   90.91%
-    Req/Sec   156.00     30.59   221.00     63.64%
-  627 requests in 2.00s, 231.33KB read
-  Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    313.51
-Transfer/sec:    115.67KB
+    Latency    45.41ms   28.75ms  93.36ms   63.64%
+    Req/Sec   139.95     33.50   192.00     54.55%
+  586 requests in 2.01s, 216.00KB read
+  Socket errors: connect 0, read 8, write 0, timeout 0
+Requests/sec:    291.88
+Transfer/sec:    107.59KB

--- a/04_erb_layout/deas-0.29.0/Gemfile
+++ b/04_erb_layout/deas-0.29.0/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "deas", "= 0.29.0"
+gem "deas-erubis", "~> 0.3"

--- a/04_erb_layout/deas-0.29.0/Gemfile.lock
+++ b/04_erb_layout/deas-0.29.0/Gemfile.lock
@@ -1,0 +1,27 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    deas (0.29.0)
+      ns-options (~> 1.1, >= 1.1.4)
+      rack (~> 1.5)
+      sinatra (~> 1.4)
+    deas-erubis (0.3.0)
+      deas (~> 0.29)
+      erubis
+    erubis (2.7.0)
+    ns-options (1.1.6)
+    rack (1.5.2)
+    rack-protection (1.5.3)
+      rack
+    sinatra (1.4.5)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
+    tilt (1.4.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  deas (= 0.29.0)
+  deas-erubis (~> 0.3)

--- a/04_erb_layout/deas-0.29.0/basic_w_layout.html.erb
+++ b/04_erb_layout/deas-0.29.0/basic_w_layout.html.erb
@@ -1,0 +1,2 @@
+<h1>An Erb Template!</h1>
+<p>Some markup up in this layout</p>

--- a/04_erb_layout/deas-0.29.0/bench_results.txt
+++ b/04_erb_layout/deas-0.29.0/bench_results.txt
@@ -1,0 +1,9 @@
+Running 2s test @ http://0.0.0.0:9292
+  2 threads and 10 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency    28.40ms   19.21ms  74.60ms   85.00%
+    Req/Sec   160.15     11.22   171.00     80.00%
+  638 requests in 2.00s, 234.82KB read
+  Socket errors: connect 0, read 4, write 0, timeout 0
+Requests/sec:    318.90
+Transfer/sec:    117.37KB

--- a/04_erb_layout/deas-0.29.0/config.ru
+++ b/04_erb_layout/deas-0.29.0/config.ru
@@ -1,0 +1,32 @@
+require 'rubygems'
+require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+
+require 'deas'
+require 'deas-erubis'
+
+class App
+  include Deas::Server
+
+  root       File.expand_path('..', __FILE__)
+  views_root File.expand_path('..', __FILE__)
+
+  s = Deas::TemplateSource.new(self.views_root).tap do |s|
+    s.engine('erb', Deas::Erubis::TemplateEngine, 'cache' => true)
+  end
+  template_source s
+
+  get '/', 'App::ErbWithLayout'
+
+  class ErbWithLayout
+    include Deas::ViewHandler
+
+    layout 'layout.html'
+
+    def run!
+      render 'basic_w_layout.html'
+    end
+  end
+
+end
+
+run App.new

--- a/04_erb_layout/deas-0.29.0/layout.html.erb
+++ b/04_erb_layout/deas-0.29.0/layout.html.erb
@@ -1,0 +1,3 @@
+<div class="layout">
+  <%= yield %>
+</div>

--- a/04_erb_layout/sinatra-1.4.5/bench_results.txt
+++ b/04_erb_layout/sinatra-1.4.5/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    34.70ms   23.83ms  82.23ms   76.74%
-    Req/Sec   160.44     77.23   250.00     67.44%
-  654 requests in 2.00s, 240.69KB read
+    Latency    28.28ms   17.24ms  80.07ms   90.00%
+    Req/Sec   154.05     31.91   222.00     75.00%
+  625 requests in 2.00s, 230.32KB read
   Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    326.92
-Transfer/sec:    120.32KB
+Requests/sec:    312.37
+Transfer/sec:    115.11KB

--- a/05_erb_layout_partial/deas-0.25.0/bench_results.txt
+++ b/05_erb_layout_partial/deas-0.25.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    40.72ms   25.47ms  82.04ms   70.00%
-    Req/Sec   144.20     19.98   185.00     65.00%
-  571 requests in 2.00s, 234.19KB read
-  Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    285.43
-Transfer/sec:    117.07KB
+    Latency    37.92ms   25.44ms  85.94ms   77.78%
+    Req/Sec   135.56     22.21   187.00     72.22%
+  550 requests in 2.00s, 225.05KB read
+  Socket errors: connect 0, read 7, write 0, timeout 0
+Requests/sec:    274.93
+Transfer/sec:    112.50KB

--- a/05_erb_layout_partial/deas-0.27.0/bench_results.txt
+++ b/05_erb_layout_partial/deas-0.27.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    25.97ms   12.19ms  80.30ms   95.45%
-    Req/Sec   141.59     27.25   208.00     81.82%
-  570 requests in 2.02s, 233.51KB read
-  Socket errors: connect 0, read 3, write 1, timeout 0
-Requests/sec:    281.76
-Transfer/sec:    115.43KB
+    Latency    33.80ms   20.48ms  80.40ms   84.21%
+    Req/Sec   138.58     26.60   188.00     63.16%
+  567 requests in 2.00s, 232.56KB read
+  Socket errors: connect 0, read 4, write 1, timeout 0
+Requests/sec:    283.48
+Transfer/sec:    116.27KB

--- a/05_erb_layout_partial/deas-0.28.0/bench_results.txt
+++ b/05_erb_layout_partial/deas-0.28.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    37.73ms   23.86ms  85.54ms   77.27%
-    Req/Sec   138.91     29.99   193.00     72.73%
-  567 requests in 2.00s, 232.83KB read
-  Socket errors: connect 0, read 6, write 1, timeout 0
-Requests/sec:    283.48
-Transfer/sec:    116.41KB
+    Latency    30.23ms   17.89ms  82.53ms   90.00%
+    Req/Sec   135.95     27.52   200.00     65.00%
+  564 requests in 2.00s, 231.33KB read
+  Socket errors: connect 0, read 4, write 0, timeout 0
+Requests/sec:    281.80
+Transfer/sec:    115.59KB

--- a/05_erb_layout_partial/deas-0.29.0/Gemfile
+++ b/05_erb_layout_partial/deas-0.29.0/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "deas", "= 0.29.0"
+gem "deas-erubis", "~> 0.3"

--- a/05_erb_layout_partial/deas-0.29.0/Gemfile.lock
+++ b/05_erb_layout_partial/deas-0.29.0/Gemfile.lock
@@ -1,0 +1,27 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    deas (0.29.0)
+      ns-options (~> 1.1, >= 1.1.4)
+      rack (~> 1.5)
+      sinatra (~> 1.4)
+    deas-erubis (0.3.0)
+      deas (~> 0.29)
+      erubis
+    erubis (2.7.0)
+    ns-options (1.1.6)
+    rack (1.5.2)
+    rack-protection (1.5.3)
+      rack
+    sinatra (1.4.5)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
+    tilt (1.4.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  deas (= 0.29.0)
+  deas-erubis (~> 0.3)

--- a/05_erb_layout_partial/deas-0.29.0/_partial.html.erb
+++ b/05_erb_layout_partial/deas-0.29.0/_partial.html.erb
@@ -1,0 +1,2 @@
+<h2>Some Partial Content</h2>
+<p>up in here</p>

--- a/05_erb_layout_partial/deas-0.29.0/basic_w_layout_and_partial.html.erb
+++ b/05_erb_layout_partial/deas-0.29.0/basic_w_layout_and_partial.html.erb
@@ -1,0 +1,3 @@
+<h1>An Erb Template!</h1>
+<p>Some markup up in here</p>
+<%= partial '_partial.html' %>

--- a/05_erb_layout_partial/deas-0.29.0/bench_results.txt
+++ b/05_erb_layout_partial/deas-0.29.0/bench_results.txt
@@ -1,0 +1,9 @@
+Running 2s test @ http://0.0.0.0:9292
+  2 threads and 10 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency    38.06ms   25.19ms  76.51ms   68.42%
+    Req/Sec   153.26      8.45   168.00     73.68%
+  600 requests in 2.00s, 246.34KB read
+  Socket errors: connect 0, read 6, write 1, timeout 0
+Requests/sec:    299.86
+Transfer/sec:    123.11KB

--- a/05_erb_layout_partial/deas-0.29.0/config.ru
+++ b/05_erb_layout_partial/deas-0.29.0/config.ru
@@ -1,0 +1,32 @@
+require 'rubygems'
+require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+
+require 'deas'
+require 'deas-erubis'
+
+class App
+  include Deas::Server
+
+  root       File.expand_path('..', __FILE__)
+  views_root File.expand_path('..', __FILE__)
+
+  s = Deas::TemplateSource.new(self.views_root).tap do |s|
+    s.engine('erb', Deas::Erubis::TemplateEngine, 'cache' => true)
+  end
+  template_source s
+
+  get '/', 'App::ErbWithLayoutAndPartial'
+
+  class ErbWithLayoutAndPartial
+    include Deas::ViewHandler
+
+    layout 'layout.html'
+
+    def run!
+      render 'basic_w_layout_and_partial.html'
+    end
+  end
+
+end
+
+run App.new

--- a/05_erb_layout_partial/deas-0.29.0/layout.html.erb
+++ b/05_erb_layout_partial/deas-0.29.0/layout.html.erb
@@ -1,0 +1,3 @@
+<div class="layout">
+  <%= yield %>
+</div>

--- a/05_erb_layout_partial/sinatra-1.4.5/bench_results.txt
+++ b/05_erb_layout_partial/sinatra-1.4.5/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    36.73ms   25.29ms  80.81ms   72.73%
-    Req/Sec   160.57     89.94   273.00     70.45%
-  640 requests in 2.00s, 261.88KB read
-  Socket errors: connect 0, read 7, write 0, timeout 0
-Requests/sec:    319.66
-Transfer/sec:    130.80KB
+    Latency    33.38ms   22.06ms  76.67ms   80.00%
+    Req/Sec   156.30     32.77   220.00     70.00%
+  620 requests in 2.00s, 253.69KB read
+  Socket errors: connect 0, read 4, write 0, timeout 0
+Requests/sec:    309.77
+Transfer/sec:    126.75KB

--- a/06_hello_many_routes/deas-0.25.0/bench_results.txt
+++ b/06_hello_many_routes/deas-0.25.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    36.88ms   24.07ms  84.05ms   73.08%
-    Req/Sec   157.12     42.21   222.00     50.00%
-  635 requests in 2.00s, 177.97KB read
+    Latency    32.71ms   21.14ms  80.95ms   83.33%
+    Req/Sec   154.96     42.33   233.00     54.17%
+  610 requests in 2.00s, 170.97KB read
   Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    317.39
-Transfer/sec:     88.95KB
+Requests/sec:    304.89
+Transfer/sec:     85.45KB

--- a/06_hello_many_routes/deas-0.27.0/bench_results.txt
+++ b/06_hello_many_routes/deas-0.27.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    35.92ms   21.92ms  78.51ms   76.92%
-    Req/Sec   153.54     36.85   219.00     50.00%
-  618 requests in 2.00s, 173.76KB read
-  Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    308.99
-Transfer/sec:     86.88KB
+    Latency    36.27ms   23.33ms  77.89ms   76.00%
+    Req/Sec   151.12     38.82   222.00     64.00%
+  602 requests in 2.00s, 168.72KB read
+  Socket errors: connect 0, read 7, write 0, timeout 0
+Requests/sec:    300.80
+Transfer/sec:     84.30KB

--- a/06_hello_many_routes/deas-0.28.0/bench_results.txt
+++ b/06_hello_many_routes/deas-0.28.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    25.80ms   10.75ms  75.69ms   95.83%
-    Req/Sec   153.92     38.68   231.00     75.00%
-  618 requests in 2.00s, 173.48KB read
+    Latency    34.25ms   22.75ms  90.08ms   83.33%
+    Req/Sec   152.33     38.05   218.00     58.33%
+  601 requests in 2.00s, 168.72KB read
   Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    308.93
-Transfer/sec:     86.72KB
+Requests/sec:    300.38
+Transfer/sec:     84.33KB

--- a/06_hello_many_routes/deas-0.29.0/Gemfile
+++ b/06_hello_many_routes/deas-0.29.0/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "deas", "= 0.29.0"

--- a/06_hello_many_routes/deas-0.29.0/Gemfile.lock
+++ b/06_hello_many_routes/deas-0.29.0/Gemfile.lock
@@ -1,0 +1,22 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    deas (0.29.0)
+      ns-options (~> 1.1, >= 1.1.4)
+      rack (~> 1.5)
+      sinatra (~> 1.4)
+    ns-options (1.1.6)
+    rack (1.5.2)
+    rack-protection (1.5.3)
+      rack
+    sinatra (1.4.5)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
+    tilt (1.4.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  deas (= 0.29.0)

--- a/06_hello_many_routes/deas-0.29.0/bench_results.txt
+++ b/06_hello_many_routes/deas-0.29.0/bench_results.txt
@@ -1,0 +1,9 @@
+Running 2s test @ http://0.0.0.0:9292
+  2 threads and 10 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency    41.29ms   25.98ms  84.14ms   70.83%
+    Req/Sec   148.04     37.45   211.00     66.67%
+  602 requests in 2.00s, 169.00KB read
+  Socket errors: connect 0, read 4, write 0, timeout 0
+Requests/sec:    300.76
+Transfer/sec:     84.43KB

--- a/06_hello_many_routes/deas-0.29.0/config.ru
+++ b/06_hello_many_routes/deas-0.29.0/config.ru
@@ -1,0 +1,29 @@
+require 'rubygems'
+require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+require 'deas'
+
+class App
+  include Deas::Server
+
+  root File.expand_path('..', __FILE__)
+
+  (1..100).each do |i1|
+    (1..3).each do |i2|
+      route = (1..i2).inject("/#{i1}"){ |r, t| r += "/#{t}"; r }
+      get route, 'App::Hello'
+    end
+  end
+
+  get '/', 'App::Hello'
+
+  class Hello
+    include Deas::ViewHandler
+
+    def run!
+      'Hello!'
+    end
+  end
+
+end
+
+run App.new

--- a/06_hello_many_routes/sinatra-1.4.5/bench_results.txt
+++ b/06_hello_many_routes/sinatra-1.4.5/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    29.64ms   17.83ms  74.26ms   86.36%
-    Req/Sec   160.95     36.37   233.00     68.18%
-  639 requests in 2.00s, 179.64KB read
-  Socket errors: connect 0, read 6, write 0, timeout 0
-Requests/sec:    319.35
-Transfer/sec:     89.78KB
+    Latency    25.55ms   12.35ms  76.47ms   94.74%
+    Req/Sec   160.84     24.59   209.00     63.16%
+  642 requests in 2.00s, 180.76KB read
+  Socket errors: connect 0, read 7, write 0, timeout 0
+Requests/sec:    320.88
+Transfer/sec:     90.35KB

--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ Single "Hello World" endpoint
 
 |    Version    | Requests/sec | Transfer/sec |
 | ------------- | ------------ | ------------ |
-|   deas-0.28.0 |       428.91 |     120.49KB |
-|   deas-0.27.0 |       419.98 |     117.85KB |
-|   deas-0.25.0 |       424.93 |     119.51KB |
-| sinatra-1.4.5 |       452.88 |     127.07KB |
+|   deas-0.29.0 |       417.44 |     117.00KB |
+|   deas-0.28.0 |       418.24 |     117.63KB |
+|   deas-0.27.0 |       404.93 |     114.04KB |
+|   deas-0.25.0 |       417.49 |     117.15KB |
+| sinatra-1.4.5 |       440.80 |     123.82KB |
 
 ### 02_erb_basic
 
@@ -21,10 +22,11 @@ Single endpoint rendering with no partials or layouts.
 
 |    Version    | Requests/sec | Transfer/sec |
 | ------------- | ------------ | ------------ |
-|   deas-0.28.0 |       346.80 |     114.61KB |
-|   deas-0.27.0 |       356.80 |     117.77KB |
-|   deas-0.25.0 |       363.82 |     120.36KB |
-| sinatra-1.4.5 |       379.54 |     125.28KB |
+|   deas-0.29.0 |       356.52 |     117.82KB |
+|   deas-0.28.0 |       323.01 |     106.75KB |
+|   deas-0.27.0 |       348.29 |     114.96KB |
+|   deas-0.25.0 |       348.03 |     115.02KB |
+| sinatra-1.4.5 |       366.94 |     121.12KB |
 
 ### 03_erb_partial
 
@@ -32,10 +34,11 @@ Single endpoint rendering a partial with no layout.
 
 |    Version    | Requests/sec | Transfer/sec |
 | ------------- | ------------ | ------------ |
-|   deas-0.28.0 |       311.86 |     118.44KB |
-|   deas-0.27.0 |       310.76 |     118.16KB |
-|   deas-0.25.0 |       320.87 |     121.58KB |
-| sinatra-1.4.5 |       326.50 |     123.99KB |
+|   deas-0.29.0 |       347.44 |     131.79KB |
+|   deas-0.28.0 |       292.33 |     110.90KB |
+|   deas-0.27.0 |       310.93 |     117.95KB |
+|   deas-0.25.0 |       307.21 |     116.68KB |
+| sinatra-1.4.5 |       322.33 |     122.27KB |
 
 ### 04_erb_layout
 
@@ -43,10 +46,11 @@ Single endpoint rendering in a layout.
 
 |    Version    | Requests/sec | Transfer/sec |
 | ------------- | ------------ | ------------ |
-|   deas-0.28.0 |       313.51 |     115.67KB |
-|   deas-0.27.0 |       316.25 |     116.40KB |
-|   deas-0.25.0 |       317.35 |     116.66KB |
-| sinatra-1.4.5 |       326.92 |     120.32KB |
+|   deas-0.29.0 |       318.90 |     117.37KB |
+|   deas-0.28.0 |       291.88 |     107.59KB |
+|   deas-0.27.0 |       316.45 |     116.61KB |
+|   deas-0.25.0 |       317.88 |     117.13KB |
+| sinatra-1.4.5 |       312.37 |     115.11KB |
 
 ### 05_erb_layout_partial
 
@@ -54,10 +58,11 @@ Single endpoint rendering a partial in a layout.
 
 |    Version    | Requests/sec | Transfer/sec |
 | ------------- | ------------ | ------------ |
-|   deas-0.28.0 |       283.48 |     116.41KB |
-|   deas-0.27.0 |       281.76 |     115.43KB |
-|   deas-0.25.0 |       285.43 |     117.07KB |
-| sinatra-1.4.5 |       319.66 |     130.80KB |
+|   deas-0.29.0 |       299.86 |     123.11KB |
+|   deas-0.28.0 |       281.80 |     115.59KB |
+|   deas-0.27.0 |       283.48 |     116.27KB |
+|   deas-0.25.0 |       274.93 |     112.50KB |
+| sinatra-1.4.5 |       309.77 |     126.75KB |
 
 ### 06_hello_many_routes
 
@@ -65,10 +70,11 @@ Single endpoint rendering a partial in a layout.
 
 |    Version    | Requests/sec | Transfer/sec |
 | ------------- | ------------ | ------------ |
-|   deas-0.28.0 |       308.93 |      86.72KB |
-|   deas-0.27.0 |       308.99 |      86.88KB |
-|   deas-0.25.0 |       317.39 |      88.95KB |
-| sinatra-1.4.5 |       319.35 |      89.78KB |
+|   deas-0.29.0 |       300.76 |      84.43KB |
+|   deas-0.28.0 |       300.38 |      84.33KB |
+|   deas-0.27.0 |       300.80 |      84.30KB |
+|   deas-0.25.0 |       304.89 |      85.45KB |
+| sinatra-1.4.5 |       320.88 |      90.35KB |
 
 ## Usage
 


### PR DESCRIPTION
Just adding another version for comparison.  This version uses
the template source and deas-erubis to render erb.  Outperforms
all other Deas versions at rendering Erb.  Outperforms sinatra
rendering erb partials.

@jcredding FYI.  finally got deas and deas-erubis working correctly and optimized.  Looks like deas-erubis doesn't hurt performance at all.