### PR TITLE
Bench using deas v0.31 with deas-erubis v0.4

### DIFF
--- a/01_hello/deas-0.25.0/bench_results.txt
+++ b/01_hello/deas-0.25.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    34.56ms   27.01ms  79.08ms   67.86%
-    Req/Sec   210.29    113.96   371.00     71.43%
-  836 requests in 2.00s, 234.58KB read
-  Socket errors: connect 0, read 7, write 0, timeout 0
-Requests/sec:    417.49
-Transfer/sec:    117.15KB
+    Latency    31.62ms   25.23ms  73.58ms   72.00%
+    Req/Sec   218.96    123.46   368.00     72.00%
+  861 requests in 2.00s, 241.86KB read
+  Socket errors: connect 0, read 3, write 0, timeout 0
+Requests/sec:    430.22
+Transfer/sec:    120.85KB

--- a/01_hello/deas-0.27.0/bench_results.txt
+++ b/01_hello/deas-0.27.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    34.44ms   26.73ms  75.42ms   68.92%
-    Req/Sec   203.64    113.59   350.00     70.27%
-  810 requests in 2.00s, 228.12KB read
+    Latency    31.13ms   24.94ms  74.62ms   72.46%
+    Req/Sec   221.03    116.37   357.00     66.67%
+  874 requests in 2.00s, 244.96KB read
   Socket errors: connect 0, read 6, write 0, timeout 0
-Requests/sec:    404.93
-Transfer/sec:    114.04KB
+Requests/sec:    437.01
+Transfer/sec:    122.48KB

--- a/01_hello/deas-0.28.0/bench_results.txt
+++ b/01_hello/deas-0.28.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    31.54ms   25.54ms  78.07ms   73.42%
-    Req/Sec   211.23    119.19   368.00     67.09%
-  837 requests in 2.00s, 235.41KB read
+    Latency    35.82ms   28.27ms  83.65ms   68.35%
+    Req/Sec   204.23    119.14   405.00     62.03%
+  817 requests in 2.00s, 229.53KB read
   Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    418.24
-Transfer/sec:    117.63KB
+Requests/sec:    408.36
+Transfer/sec:    114.73KB

--- a/01_hello/deas-0.29.0/Gemfile.lock
+++ b/01_hello/deas-0.29.0/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
       rack (~> 1.5)
       sinatra (~> 1.4)
     ns-options (1.1.6)
-    rack (1.5.2)
+    rack (1.6.0)
     rack-protection (1.5.3)
       rack
     sinatra (1.4.5)

--- a/01_hello/deas-0.29.0/bench_results.txt
+++ b/01_hello/deas-0.29.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    30.79ms   25.13ms  76.93ms   74.51%
-    Req/Sec   210.35    109.18   342.00     72.55%
-  835 requests in 2.00s, 234.03KB read
-  Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    417.44
-Transfer/sec:    117.00KB
+    Latency    29.32ms   24.13ms  79.43ms   76.92%
+    Req/Sec   214.08    112.76   365.00     63.08%
+  848 requests in 2.00s, 238.22KB read
+  Socket errors: connect 0, read 5, write 0, timeout 0
+Requests/sec:    423.75
+Transfer/sec:    119.04KB

--- a/01_hello/deas-0.31.0/Gemfile
+++ b/01_hello/deas-0.31.0/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "deas", "= 0.31.0"

--- a/01_hello/deas-0.31.0/Gemfile.lock
+++ b/01_hello/deas-0.31.0/Gemfile.lock
@@ -1,0 +1,22 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    deas (0.31.0)
+      ns-options (~> 1.1, >= 1.1.4)
+      rack (~> 1.5)
+      sinatra (~> 1.4)
+    ns-options (1.1.6)
+    rack (1.6.0)
+    rack-protection (1.5.3)
+      rack
+    sinatra (1.4.5)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
+    tilt (1.4.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  deas (= 0.31.0)

--- a/01_hello/deas-0.31.0/bench_results.txt
+++ b/01_hello/deas-0.31.0/bench_results.txt
@@ -1,0 +1,9 @@
+Running 2s test @ http://0.0.0.0:9292
+  2 threads and 10 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency    34.10ms   26.45ms  74.02ms   67.65%
+    Req/Sec   216.65    123.52   365.00     72.06%
+  862 requests in 2.00s, 241.60KB read
+  Socket errors: connect 0, read 7, write 0, timeout 0
+Requests/sec:    430.86
+Transfer/sec:    120.76KB

--- a/01_hello/deas-0.31.0/config.ru
+++ b/01_hello/deas-0.31.0/config.ru
@@ -1,0 +1,22 @@
+require 'rubygems'
+require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+require 'deas'
+
+class App
+  include Deas::Server
+
+  root File.expand_path('..', __FILE__)
+
+  get '/', 'App::Hello'
+
+  class Hello
+    include Deas::ViewHandler
+
+    def run!
+      'Hello!'
+    end
+  end
+
+end
+
+run App.new

--- a/01_hello/sinatra-1.4.5/bench_results.txt
+++ b/01_hello/sinatra-1.4.5/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    32.18ms   25.74ms  74.86ms   70.27%
-    Req/Sec   221.69    128.79   384.00     64.86%
-  882 requests in 2.00s, 247.75KB read
-  Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    440.80
-Transfer/sec:    123.82KB
+    Latency    31.99ms   25.66ms  75.85ms   70.00%
+    Req/Sec   233.20    119.66   406.00     72.86%
+  907 requests in 2.00s, 255.03KB read
+  Socket errors: connect 0, read 5, write 0, timeout 0
+Requests/sec:    453.31
+Transfer/sec:    127.46KB

--- a/02_erb_basic/deas-0.25.0/Gemfile
+++ b/02_erb_basic/deas-0.25.0/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem "deas", "= 0.25.0"
-gem "erubis",  "~> 2.7"
+gem "deas",   "= 0.25.0"
+gem "erubis", "~> 2.7"

--- a/02_erb_basic/deas-0.25.0/bench_results.txt
+++ b/02_erb_basic/deas-0.25.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    37.46ms   26.57ms  84.00ms   70.37%
-    Req/Sec   171.33     85.69   279.00     72.22%
-  696 requests in 2.00s, 230.01KB read
-  Socket errors: connect 0, read 3, write 1, timeout 0
-Requests/sec:    348.03
-Transfer/sec:    115.02KB
+    Latency    37.69ms   26.41ms  76.62ms   66.00%
+    Req/Sec   181.30     94.08   307.00     60.00%
+  725 requests in 2.00s, 239.58KB read
+  Socket errors: connect 0, read 4, write 0, timeout 0
+Requests/sec:    361.68
+Transfer/sec:    119.52KB

--- a/02_erb_basic/deas-0.27.0/Gemfile
+++ b/02_erb_basic/deas-0.27.0/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem "deas", "= 0.27.0"
-gem "erubis",  "~> 2.7"
+gem "deas",   "= 0.27.0"
+gem "erubis", "~> 2.7"

--- a/02_erb_basic/deas-0.27.0/bench_results.txt
+++ b/02_erb_basic/deas-0.27.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    30.07ms   21.88ms  80.39ms   82.69%
-    Req/Sec   172.37     89.48   269.00     61.54%
-  697 requests in 2.00s, 230.06KB read
-  Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    348.29
-Transfer/sec:    114.96KB
+    Latency    35.01ms   25.61ms  78.63ms   70.69%
+    Req/Sec   187.10    101.41   306.00     65.52%
+  735 requests in 2.00s, 243.16KB read
+  Socket errors: connect 0, read 3, write 0, timeout 0
+Requests/sec:    367.40
+Transfer/sec:    121.55KB

--- a/02_erb_basic/deas-0.28.0/Gemfile
+++ b/02_erb_basic/deas-0.28.0/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem "deas", "= 0.28.0"
-gem "erubis",  "~> 2.7"
+gem "deas",   "= 0.28.0"
+gem "erubis", "~> 2.7"

--- a/02_erb_basic/deas-0.28.0/bench_results.txt
+++ b/02_erb_basic/deas-0.28.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    39.04ms   26.18ms  84.57ms   70.73%
-    Req/Sec   154.95     73.64   250.00     51.22%
-  646 requests in 2.00s, 213.51KB read
-  Socket errors: connect 0, read 6, write 0, timeout 0
-Requests/sec:    323.01
-Transfer/sec:    106.75KB
+    Latency    34.75ms   24.23ms  79.26ms   73.58%
+    Req/Sec   173.47     79.22   271.00     52.83%
+  692 requests in 2.00s, 228.96KB read
+  Socket errors: connect 0, read 4, write 0, timeout 0
+Requests/sec:    345.73
+Transfer/sec:    114.39KB

--- a/02_erb_basic/deas-0.29.0/Gemfile
+++ b/02_erb_basic/deas-0.29.0/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem "deas", "= 0.29.0"
+gem "deas",        "= 0.29.0"
 gem "deas-erubis", "~> 0.3"

--- a/02_erb_basic/deas-0.29.0/bench_results.txt
+++ b/02_erb_basic/deas-0.29.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    31.90ms   23.77ms  76.67ms   77.27%
-    Req/Sec   178.45     37.19   248.00     59.09%
-  713 requests in 2.00s, 235.62KB read
-  Socket errors: connect 0, read 7, write 0, timeout 0
-Requests/sec:    356.52
-Transfer/sec:    117.82KB
+    Latency    27.29ms   20.58ms  71.21ms   81.82%
+    Req/Sec   191.55     30.98   254.00     68.18%
+  756 requests in 2.00s, 250.09KB read
+  Socket errors: connect 0, read 8, write 0, timeout 0
+Requests/sec:    378.01
+Transfer/sec:    125.05KB

--- a/02_erb_basic/deas-0.31.0/Gemfile
+++ b/02_erb_basic/deas-0.31.0/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "deas",        "= 0.31.0"
+gem "deas-erubis", "~> 0.4"

--- a/02_erb_basic/deas-0.31.0/Gemfile.lock
+++ b/02_erb_basic/deas-0.31.0/Gemfile.lock
@@ -1,0 +1,27 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    deas (0.31.0)
+      ns-options (~> 1.1, >= 1.1.4)
+      rack (~> 1.5)
+      sinatra (~> 1.4)
+    deas-erubis (0.4.0)
+      deas (~> 0.30)
+      erubis
+    erubis (2.7.0)
+    ns-options (1.1.6)
+    rack (1.6.0)
+    rack-protection (1.5.3)
+      rack
+    sinatra (1.4.5)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
+    tilt (1.4.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  deas (= 0.31.0)
+  deas-erubis (~> 0.4)

--- a/02_erb_basic/deas-0.31.0/basic.html.erb
+++ b/02_erb_basic/deas-0.31.0/basic.html.erb
@@ -1,0 +1,2 @@
+<h1>An Erb Template!</h1>
+<p>Some markup up in here</p>

--- a/02_erb_basic/deas-0.31.0/bench_results.txt
+++ b/02_erb_basic/deas-0.31.0/bench_results.txt
@@ -1,0 +1,9 @@
+Running 2s test @ http://0.0.0.0:9292
+  2 threads and 10 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency    33.70ms   25.36ms  77.30ms   71.43%
+    Req/Sec   202.57     98.65   326.00     67.35%
+  803 requests in 2.00s, 265.33KB read
+  Socket errors: connect 0, read 7, write 0, timeout 0
+Requests/sec:    401.50
+Transfer/sec:    132.66KB

--- a/02_erb_basic/deas-0.31.0/config.ru
+++ b/02_erb_basic/deas-0.31.0/config.ru
@@ -1,0 +1,30 @@
+require 'rubygems'
+require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+
+require 'deas'
+require 'deas-erubis'
+
+class App
+  include Deas::Server
+
+  root       File.expand_path('..', __FILE__)
+  views_root File.expand_path('..', __FILE__)
+
+  s = Deas::TemplateSource.new(self.views_root).tap do |s|
+    s.engine('erb', Deas::Erubis::TemplateEngine, 'cache' => true)
+  end
+  template_source s
+
+  get '/', 'App::ErbBasic'
+
+  class ErbBasic
+    include Deas::ViewHandler
+
+    def run!
+      render 'basic.html'
+    end
+  end
+
+end
+
+run App.new

--- a/02_erb_basic/sinatra-1.4.5/bench_results.txt
+++ b/02_erb_basic/sinatra-1.4.5/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    31.88ms   23.16ms  76.71ms   77.55%
-    Req/Sec   182.39     78.48   319.00     69.39%
-  734 requests in 2.00s, 242.28KB read
-  Socket errors: connect 0, read 6, write 0, timeout 0
-Requests/sec:    366.94
-Transfer/sec:    121.12KB
+    Latency    28.39ms   21.51ms  79.00ms   82.14%
+    Req/Sec   184.54     59.73   277.00     53.57%
+  758 requests in 2.00s, 250.75KB read
+  Socket errors: connect 0, read 4, write 0, timeout 0
+Requests/sec:    378.87
+Transfer/sec:    125.33KB

--- a/03_erb_partial/deas-0.25.0/bench_results.txt
+++ b/03_erb_partial/deas-0.25.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    35.36ms   23.80ms  82.10ms   78.12%
-    Req/Sec   150.75     64.54   242.00     62.50%
-  616 requests in 2.01s, 233.96KB read
-  Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    307.21
-Transfer/sec:    116.68KB
+    Latency    34.09ms   23.68ms  76.32ms   76.00%
+    Req/Sec   160.92     41.86   245.00     72.00%
+  648 requests in 2.00s, 245.81KB read
+  Socket errors: connect 0, read 6, write 0, timeout 0
+Requests/sec:    324.00
+Transfer/sec:    122.90KB

--- a/03_erb_partial/deas-0.27.0/bench_results.txt
+++ b/03_erb_partial/deas-0.27.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    27.71ms   16.28ms  81.43ms   91.67%
-    Req/Sec   150.88     39.88   229.00     70.83%
-  622 requests in 2.00s, 235.96KB read
-  Socket errors: connect 0, read 6, write 0, timeout 0
-Requests/sec:    310.93
-Transfer/sec:    117.95KB
+    Latency    24.86ms   13.57ms  83.49ms   95.24%
+    Req/Sec   158.67     23.14   201.00     57.14%
+  632 requests in 2.00s, 239.75KB read
+  Socket errors: connect 0, read 2, write 0, timeout 0
+Requests/sec:    315.94
+Transfer/sec:    119.85KB

--- a/03_erb_partial/deas-0.28.0/bench_results.txt
+++ b/03_erb_partial/deas-0.28.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    32.04ms   20.44ms  84.32ms   86.36%
-    Req/Sec   140.82     35.40   221.00     72.73%
-  585 requests in 2.00s, 221.94KB read
-  Socket errors: connect 0, read 5, write 0, timeout 0
-Requests/sec:    292.33
-Transfer/sec:    110.90KB
+    Latency    30.08ms   20.19ms  81.60ms   85.71%
+    Req/Sec   155.18     48.74   235.00     57.14%
+  621 requests in 2.00s, 235.58KB read
+  Socket errors: connect 0, read 1, write 1, timeout 0
+Requests/sec:    310.37
+Transfer/sec:    117.74KB

--- a/03_erb_partial/deas-0.29.0/Gemfile
+++ b/03_erb_partial/deas-0.29.0/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem "deas", "= 0.29.0"
+gem "deas",        "= 0.29.0"
 gem "deas-erubis", "~> 0.3"

--- a/03_erb_partial/deas-0.29.0/bench_results.txt
+++ b/03_erb_partial/deas-0.29.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    37.64ms   26.14ms  79.27ms   67.65%
-    Req/Sec   172.35     67.91   278.00     47.06%
-  695 requests in 2.00s, 263.62KB read
-  Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    347.44
-Transfer/sec:    131.79KB
+    Latency    29.21ms   21.32ms  76.77ms   83.33%
+    Req/Sec   182.92     42.89   248.00     50.00%
+  719 requests in 2.00s, 272.99KB read
+  Socket errors: connect 0, read 3, write 0, timeout 0
+Requests/sec:    359.35
+Transfer/sec:    136.44KB

--- a/03_erb_partial/deas-0.31.0/Gemfile
+++ b/03_erb_partial/deas-0.31.0/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "deas",        "= 0.31.0"
+gem "deas-erubis", "~> 0.4"

--- a/03_erb_partial/deas-0.31.0/Gemfile.lock
+++ b/03_erb_partial/deas-0.31.0/Gemfile.lock
@@ -1,0 +1,27 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    deas (0.31.0)
+      ns-options (~> 1.1, >= 1.1.4)
+      rack (~> 1.5)
+      sinatra (~> 1.4)
+    deas-erubis (0.4.0)
+      deas (~> 0.30)
+      erubis
+    erubis (2.7.0)
+    ns-options (1.1.6)
+    rack (1.6.0)
+    rack-protection (1.5.3)
+      rack
+    sinatra (1.4.5)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
+    tilt (1.4.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  deas (= 0.31.0)
+  deas-erubis (~> 0.4)

--- a/03_erb_partial/deas-0.31.0/_partial.html.erb
+++ b/03_erb_partial/deas-0.31.0/_partial.html.erb
@@ -1,0 +1,2 @@
+<h2>Some Partial Content</h2>
+<p>up in here</p>

--- a/03_erb_partial/deas-0.31.0/basic_w_partial.html.erb
+++ b/03_erb_partial/deas-0.31.0/basic_w_partial.html.erb
@@ -1,0 +1,3 @@
+<h1>An Erb Template!</h1>
+<p>Some markup up in here</p>
+<%= partial '_partial.html' %>

--- a/03_erb_partial/deas-0.31.0/bench_results.txt
+++ b/03_erb_partial/deas-0.31.0/bench_results.txt
@@ -1,0 +1,9 @@
+Running 2s test @ http://0.0.0.0:9292
+  2 threads and 10 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency    30.83ms   24.79ms  76.88ms   75.00%
+    Req/Sec   205.67     99.13   341.00     67.19%
+  804 requests in 2.00s, 306.02KB read
+  Socket errors: connect 0, read 3, write 0, timeout 0
+Requests/sec:    401.78
+Transfer/sec:    152.93KB

--- a/03_erb_partial/deas-0.31.0/config.ru
+++ b/03_erb_partial/deas-0.31.0/config.ru
@@ -1,0 +1,30 @@
+require 'rubygems'
+require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+
+require 'deas'
+require 'deas-erubis'
+
+class App
+  include Deas::Server
+
+  root       File.expand_path('..', __FILE__)
+  views_root File.expand_path('..', __FILE__)
+
+  s = Deas::TemplateSource.new(self.views_root).tap do |s|
+    s.engine('erb', Deas::Erubis::TemplateEngine, 'cache' => true)
+  end
+  template_source s
+
+  get '/', 'App::ErbPartial'
+
+  class ErbPartial
+    include Deas::ViewHandler
+
+    def run!
+      render 'basic_w_partial.html'
+    end
+  end
+
+end
+
+run App.new

--- a/03_erb_partial/sinatra-1.4.5/bench_results.txt
+++ b/03_erb_partial/sinatra-1.4.5/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    28.95ms   18.55ms  77.32ms   87.10%
-    Req/Sec   163.42     52.82   246.00     67.74%
-  645 requests in 2.00s, 244.67KB read
-  Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    322.33
-Transfer/sec:    122.27KB
+    Latency    28.90ms   19.41ms  79.85ms   86.96%
+    Req/Sec   164.35     39.38   254.00     65.22%
+  657 requests in 2.00s, 249.22KB read
+  Socket errors: connect 0, read 8, write 0, timeout 0
+Requests/sec:    328.43
+Transfer/sec:    124.58KB

--- a/04_erb_layout/deas-0.25.0/bench_results.txt
+++ b/04_erb_layout/deas-0.25.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    35.69ms   24.71ms  80.56ms   75.00%
-    Req/Sec   162.28     56.43   250.00     68.75%
-  636 requests in 2.00s, 234.36KB read
-  Socket errors: connect 0, read 7, write 0, timeout 0
-Requests/sec:    317.88
-Transfer/sec:    117.13KB
+    Latency    28.40ms   18.59ms  76.90ms   87.50%
+    Req/Sec   163.83     42.19   236.00     62.50%
+  652 requests in 2.00s, 239.68KB read
+  Socket errors: connect 0, read 10, write 0, timeout 0
+Requests/sec:    325.91
+Transfer/sec:    119.81KB

--- a/04_erb_layout/deas-0.27.0/bench_results.txt
+++ b/04_erb_layout/deas-0.27.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    35.49ms   24.93ms  81.24ms   75.00%
-    Req/Sec   152.35     28.03   204.00     60.00%
-  633 requests in 2.00s, 233.26KB read
-  Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    316.45
-Transfer/sec:    116.61KB
+    Latency    33.34ms   23.95ms  78.11ms   77.27%
+    Req/Sec   163.95     33.53   229.00     63.64%
+  640 requests in 2.00s, 235.55KB read
+  Socket errors: connect 0, read 9, write 0, timeout 0
+Requests/sec:    319.87
+Transfer/sec:    117.73KB

--- a/04_erb_layout/deas-0.28.0/bench_results.txt
+++ b/04_erb_layout/deas-0.28.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    45.41ms   28.75ms  93.36ms   63.64%
-    Req/Sec   139.95     33.50   192.00     54.55%
-  586 requests in 2.01s, 216.00KB read
-  Socket errors: connect 0, read 8, write 0, timeout 0
-Requests/sec:    291.88
-Transfer/sec:    107.59KB
+    Latency    29.20ms   18.78ms  79.02ms   88.00%
+    Req/Sec   157.12     43.99   235.00     64.00%
+  630 requests in 2.00s, 232.15KB read
+  Socket errors: connect 0, read 4, write 0, timeout 0
+Requests/sec:    314.84
+Transfer/sec:    116.02KB

--- a/04_erb_layout/deas-0.29.0/Gemfile
+++ b/04_erb_layout/deas-0.29.0/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem "deas", "= 0.29.0"
+gem "deas",        "= 0.29.0"
 gem "deas-erubis", "~> 0.3"

--- a/04_erb_layout/deas-0.29.0/bench_results.txt
+++ b/04_erb_layout/deas-0.29.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    28.40ms   19.21ms  74.60ms   85.00%
-    Req/Sec   160.15     11.22   171.00     80.00%
-  638 requests in 2.00s, 234.82KB read
-  Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    318.90
-Transfer/sec:    117.37KB
+    Latency    34.78ms   22.99ms  69.95ms   68.18%
+    Req/Sec   159.36     10.03   180.00     72.73%
+  657 requests in 2.00s, 241.79KB read
+  Socket errors: connect 0, read 6, write 0, timeout 0
+Requests/sec:    328.40
+Transfer/sec:    120.86KB

--- a/04_erb_layout/deas-0.31.0/Gemfile
+++ b/04_erb_layout/deas-0.31.0/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "deas",        "= 0.31.0"
+gem "deas-erubis", "~> 0.4"

--- a/04_erb_layout/deas-0.31.0/Gemfile.lock
+++ b/04_erb_layout/deas-0.31.0/Gemfile.lock
@@ -1,0 +1,27 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    deas (0.31.0)
+      ns-options (~> 1.1, >= 1.1.4)
+      rack (~> 1.5)
+      sinatra (~> 1.4)
+    deas-erubis (0.4.0)
+      deas (~> 0.30)
+      erubis
+    erubis (2.7.0)
+    ns-options (1.1.6)
+    rack (1.6.0)
+    rack-protection (1.5.3)
+      rack
+    sinatra (1.4.5)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
+    tilt (1.4.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  deas (= 0.31.0)
+  deas-erubis (~> 0.4)

--- a/04_erb_layout/deas-0.31.0/basic_w_layout.html.erb
+++ b/04_erb_layout/deas-0.31.0/basic_w_layout.html.erb
@@ -1,0 +1,2 @@
+<h1>An Erb Template!</h1>
+<p>Some markup up in this layout</p>

--- a/04_erb_layout/deas-0.31.0/bench_results.txt
+++ b/04_erb_layout/deas-0.31.0/bench_results.txt
@@ -1,0 +1,9 @@
+Running 2s test @ http://0.0.0.0:9292
+  2 threads and 10 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency    28.14ms   21.96ms  73.18ms   80.95%
+    Req/Sec   189.43     21.46   236.00     76.19%
+  756 requests in 2.00s, 278.70KB read
+  Socket errors: connect 0, read 10, write 0, timeout 0
+Requests/sec:    377.67
+Transfer/sec:    139.23KB

--- a/04_erb_layout/deas-0.31.0/config.ru
+++ b/04_erb_layout/deas-0.31.0/config.ru
@@ -1,0 +1,32 @@
+require 'rubygems'
+require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+
+require 'deas'
+require 'deas-erubis'
+
+class App
+  include Deas::Server
+
+  root       File.expand_path('..', __FILE__)
+  views_root File.expand_path('..', __FILE__)
+
+  s = Deas::TemplateSource.new(self.views_root).tap do |s|
+    s.engine('erb', Deas::Erubis::TemplateEngine, 'cache' => true)
+  end
+  template_source s
+
+  get '/', 'App::ErbWithLayout'
+
+  class ErbWithLayout
+    include Deas::ViewHandler
+
+    layout 'layout.html'
+
+    def run!
+      render 'basic_w_layout.html'
+    end
+  end
+
+end
+
+run App.new

--- a/04_erb_layout/deas-0.31.0/layout.html.erb
+++ b/04_erb_layout/deas-0.31.0/layout.html.erb
@@ -1,0 +1,3 @@
+<div class="layout">
+  <%= yield %>
+</div>

--- a/04_erb_layout/sinatra-1.4.5/bench_results.txt
+++ b/04_erb_layout/sinatra-1.4.5/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    28.28ms   17.24ms  80.07ms   90.00%
-    Req/Sec   154.05     31.91   222.00     75.00%
-  625 requests in 2.00s, 230.32KB read
-  Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    312.37
-Transfer/sec:    115.11KB
+    Latency    29.66ms   18.58ms  76.88ms   85.11%
+    Req/Sec   163.94     70.37   246.00     59.57%
+  668 requests in 2.00s, 245.56KB read
+  Socket errors: connect 0, read 3, write 1, timeout 0
+Requests/sec:    333.98
+Transfer/sec:    122.77KB

--- a/05_erb_layout_partial/deas-0.25.0/bench_results.txt
+++ b/05_erb_layout_partial/deas-0.25.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    37.92ms   25.44ms  85.94ms   77.78%
-    Req/Sec   135.56     22.21   187.00     72.22%
-  550 requests in 2.00s, 225.05KB read
-  Socket errors: connect 0, read 7, write 0, timeout 0
-Requests/sec:    274.93
-Transfer/sec:    112.50KB
+    Latency    30.17ms   19.39ms  79.04ms   86.36%
+    Req/Sec   150.27     31.04   206.00     50.00%
+  599 requests in 2.00s, 245.93KB read
+  Socket errors: connect 0, read 3, write 0, timeout 0
+Requests/sec:    299.37
+Transfer/sec:    122.91KB

--- a/05_erb_layout_partial/deas-0.27.0/bench_results.txt
+++ b/05_erb_layout_partial/deas-0.27.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    33.80ms   20.48ms  80.40ms   84.21%
-    Req/Sec   138.58     26.60   188.00     63.16%
-  567 requests in 2.00s, 232.56KB read
-  Socket errors: connect 0, read 4, write 1, timeout 0
-Requests/sec:    283.48
-Transfer/sec:    116.27KB
+    Latency    26.91ms   11.69ms  78.36ms   95.45%
+    Req/Sec   146.45     29.21   207.00     54.55%
+  592 requests in 2.00s, 242.79KB read
+  Socket errors: connect 0, read 3, write 1, timeout 0
+Requests/sec:    296.02
+Transfer/sec:    121.40KB

--- a/05_erb_layout_partial/deas-0.28.0/bench_results.txt
+++ b/05_erb_layout_partial/deas-0.28.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    30.23ms   17.89ms  82.53ms   90.00%
-    Req/Sec   135.95     27.52   200.00     65.00%
-  564 requests in 2.00s, 231.33KB read
+    Latency    30.81ms   19.30ms  78.25ms   86.36%
+    Req/Sec   145.55     25.94   200.00     68.18%
+  578 requests in 2.00s, 236.78KB read
   Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    281.80
-Transfer/sec:    115.59KB
+Requests/sec:    288.86
+Transfer/sec:    118.34KB

--- a/05_erb_layout_partial/deas-0.29.0/Gemfile
+++ b/05_erb_layout_partial/deas-0.29.0/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem "deas", "= 0.29.0"
+gem "deas",        "= 0.29.0"
 gem "deas-erubis", "~> 0.3"

--- a/05_erb_layout_partial/deas-0.29.0/bench_results.txt
+++ b/05_erb_layout_partial/deas-0.29.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    38.06ms   25.19ms  76.51ms   68.42%
-    Req/Sec   153.26      8.45   168.00     73.68%
-  600 requests in 2.00s, 246.34KB read
-  Socket errors: connect 0, read 6, write 1, timeout 0
-Requests/sec:    299.86
-Transfer/sec:    123.11KB
+    Latency    25.10ms   14.62ms  68.62ms   90.00%
+    Req/Sec   160.65     10.49   176.00     65.00%
+  642 requests in 2.00s, 263.25KB read
+  Socket errors: connect 0, read 5, write 0, timeout 0
+Requests/sec:    320.99
+Transfer/sec:    131.62KB

--- a/05_erb_layout_partial/deas-0.31.0/Gemfile
+++ b/05_erb_layout_partial/deas-0.31.0/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "deas",        "= 0.31.0"
+gem "deas-erubis", "~> 0.4"

--- a/05_erb_layout_partial/deas-0.31.0/Gemfile.lock
+++ b/05_erb_layout_partial/deas-0.31.0/Gemfile.lock
@@ -1,0 +1,27 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    deas (0.31.0)
+      ns-options (~> 1.1, >= 1.1.4)
+      rack (~> 1.5)
+      sinatra (~> 1.4)
+    deas-erubis (0.4.0)
+      deas (~> 0.30)
+      erubis
+    erubis (2.7.0)
+    ns-options (1.1.6)
+    rack (1.6.0)
+    rack-protection (1.5.3)
+      rack
+    sinatra (1.4.5)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
+    tilt (1.4.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  deas (= 0.31.0)
+  deas-erubis (~> 0.4)

--- a/05_erb_layout_partial/deas-0.31.0/_partial.html.erb
+++ b/05_erb_layout_partial/deas-0.31.0/_partial.html.erb
@@ -1,0 +1,2 @@
+<h2>Some Partial Content</h2>
+<p>up in here</p>

--- a/05_erb_layout_partial/deas-0.31.0/basic_w_layout_and_partial.html.erb
+++ b/05_erb_layout_partial/deas-0.31.0/basic_w_layout_and_partial.html.erb
@@ -1,0 +1,3 @@
+<h1>An Erb Template!</h1>
+<p>Some markup up in here</p>
+<%= partial '_partial.html' %>

--- a/05_erb_layout_partial/deas-0.31.0/bench_results.txt
+++ b/05_erb_layout_partial/deas-0.31.0/bench_results.txt
@@ -1,0 +1,9 @@
+Running 2s test @ http://0.0.0.0:9292
+  2 threads and 10 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency    27.11ms   21.85ms  74.97ms   81.82%
+    Req/Sec   194.77     29.25   252.00     63.64%
+  768 requests in 2.00s, 314.80KB read
+  Socket errors: connect 0, read 9, write 0, timeout 0
+Requests/sec:    383.91
+Transfer/sec:    157.36KB

--- a/05_erb_layout_partial/deas-0.31.0/config.ru
+++ b/05_erb_layout_partial/deas-0.31.0/config.ru
@@ -1,0 +1,32 @@
+require 'rubygems'
+require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+
+require 'deas'
+require 'deas-erubis'
+
+class App
+  include Deas::Server
+
+  root       File.expand_path('..', __FILE__)
+  views_root File.expand_path('..', __FILE__)
+
+  s = Deas::TemplateSource.new(self.views_root).tap do |s|
+    s.engine('erb', Deas::Erubis::TemplateEngine, 'cache' => true)
+  end
+  template_source s
+
+  get '/', 'App::ErbWithLayoutAndPartial'
+
+  class ErbWithLayoutAndPartial
+    include Deas::ViewHandler
+
+    layout 'layout.html'
+
+    def run!
+      render 'basic_w_layout_and_partial.html'
+    end
+  end
+
+end
+
+run App.new

--- a/05_erb_layout_partial/deas-0.31.0/layout.html.erb
+++ b/05_erb_layout_partial/deas-0.31.0/layout.html.erb
@@ -1,0 +1,3 @@
+<div class="layout">
+  <%= yield %>
+</div>

--- a/05_erb_layout_partial/sinatra-1.4.5/bench_results.txt
+++ b/05_erb_layout_partial/sinatra-1.4.5/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    33.38ms   22.06ms  76.67ms   80.00%
-    Req/Sec   156.30     32.77   220.00     70.00%
-  620 requests in 2.00s, 253.69KB read
+    Latency    37.44ms   25.09ms  77.40ms   70.00%
+    Req/Sec   160.32     72.16   294.00     60.00%
+  644 requests in 2.00s, 263.51KB read
   Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    309.77
-Transfer/sec:    126.75KB
+Requests/sec:    321.89
+Transfer/sec:    131.71KB

--- a/06_hello_many_routes/deas-0.25.0/bench_results.txt
+++ b/06_hello_many_routes/deas-0.25.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    32.71ms   21.14ms  80.95ms   83.33%
-    Req/Sec   154.96     42.33   233.00     54.17%
-  610 requests in 2.00s, 170.97KB read
+    Latency    34.71ms   21.91ms  76.25ms   76.92%
+    Req/Sec   162.00     42.28   230.00     65.38%
+  644 requests in 2.00s, 180.77KB read
   Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    304.89
-Transfer/sec:     85.45KB
+Requests/sec:    321.90
+Transfer/sec:     90.36KB

--- a/06_hello_many_routes/deas-0.27.0/bench_results.txt
+++ b/06_hello_many_routes/deas-0.27.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    36.27ms   23.33ms  77.89ms   76.00%
-    Req/Sec   151.12     38.82   222.00     64.00%
-  602 requests in 2.00s, 168.72KB read
-  Socket errors: connect 0, read 7, write 0, timeout 0
-Requests/sec:    300.80
-Transfer/sec:     84.30KB
+    Latency    24.75ms    9.90ms  72.63ms   96.15%
+    Req/Sec   160.23     50.55   225.00     50.00%
+  643 requests in 2.00s, 180.49KB read
+  Socket errors: connect 0, read 4, write 0, timeout 0
+Requests/sec:    321.30
+Transfer/sec:     90.19KB

--- a/06_hello_many_routes/deas-0.28.0/bench_results.txt
+++ b/06_hello_many_routes/deas-0.28.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    34.25ms   22.75ms  90.08ms   83.33%
-    Req/Sec   152.33     38.05   218.00     58.33%
-  601 requests in 2.00s, 168.72KB read
+    Latency    34.88ms   23.76ms  91.57ms   80.77%
+    Req/Sec   158.04     45.81   231.00     61.54%
+  634 requests in 2.00s, 178.79KB read
   Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    300.38
-Transfer/sec:     84.33KB
+Requests/sec:    316.95
+Transfer/sec:     89.38KB

--- a/06_hello_many_routes/deas-0.29.0/bench_results.txt
+++ b/06_hello_many_routes/deas-0.29.0/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    41.29ms   25.98ms  84.14ms   70.83%
-    Req/Sec   148.04     37.45   211.00     66.67%
-  602 requests in 2.00s, 169.00KB read
+    Latency    32.99ms   22.11ms  81.90ms   80.77%
+    Req/Sec   160.81     43.19   225.00     53.85%
+  641 requests in 2.00s, 179.93KB read
   Socket errors: connect 0, read 4, write 0, timeout 0
-Requests/sec:    300.76
-Transfer/sec:     84.43KB
+Requests/sec:    320.44
+Transfer/sec:     89.95KB

--- a/06_hello_many_routes/deas-0.31.0/Gemfile
+++ b/06_hello_many_routes/deas-0.31.0/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "deas", "= 0.31.0"

--- a/06_hello_many_routes/deas-0.31.0/Gemfile.lock
+++ b/06_hello_many_routes/deas-0.31.0/Gemfile.lock
@@ -1,0 +1,22 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    deas (0.31.0)
+      ns-options (~> 1.1, >= 1.1.4)
+      rack (~> 1.5)
+      sinatra (~> 1.4)
+    ns-options (1.1.6)
+    rack (1.6.0)
+    rack-protection (1.5.3)
+      rack
+    sinatra (1.4.5)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
+    tilt (1.4.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  deas (= 0.31.0)

--- a/06_hello_many_routes/deas-0.31.0/bench_results.txt
+++ b/06_hello_many_routes/deas-0.31.0/bench_results.txt
@@ -1,0 +1,9 @@
+Running 2s test @ http://0.0.0.0:9292
+  2 threads and 10 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency    35.00ms   22.28ms  79.56ms   77.42%
+    Req/Sec   158.94     51.02   234.00     61.29%
+  638 requests in 2.00s, 179.09KB read
+  Socket errors: connect 0, read 6, write 0, timeout 0
+Requests/sec:    318.83
+Transfer/sec:     89.50KB

--- a/06_hello_many_routes/deas-0.31.0/config.ru
+++ b/06_hello_many_routes/deas-0.31.0/config.ru
@@ -1,0 +1,29 @@
+require 'rubygems'
+require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+require 'deas'
+
+class App
+  include Deas::Server
+
+  root File.expand_path('..', __FILE__)
+
+  (1..100).each do |i1|
+    (1..3).each do |i2|
+      route = (1..i2).inject("/#{i1}"){ |r, t| r += "/#{t}"; r }
+      get route, 'App::Hello'
+    end
+  end
+
+  get '/', 'App::Hello'
+
+  class Hello
+    include Deas::ViewHandler
+
+    def run!
+      'Hello!'
+    end
+  end
+
+end
+
+run App.new

--- a/06_hello_many_routes/sinatra-1.4.5/bench_results.txt
+++ b/06_hello_many_routes/sinatra-1.4.5/bench_results.txt
@@ -1,9 +1,9 @@
 Running 2s test @ http://0.0.0.0:9292
   2 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    25.55ms   12.35ms  76.47ms   94.74%
-    Req/Sec   160.84     24.59   209.00     63.16%
-  642 requests in 2.00s, 180.76KB read
-  Socket errors: connect 0, read 7, write 0, timeout 0
-Requests/sec:    320.88
-Transfer/sec:     90.35KB
+    Latency    31.80ms   19.43ms  75.87ms   83.33%
+    Req/Sec   164.88     44.93   237.00     62.50%
+  641 requests in 2.00s, 180.48KB read
+  Socket errors: connect 0, read 3, write 0, timeout 0
+Requests/sec:    320.44
+Transfer/sec:     90.22KB

--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ Single "Hello World" endpoint
 
 |    Version    | Requests/sec | Transfer/sec |
 | ------------- | ------------ | ------------ |
-|   deas-0.29.0 |       417.44 |     117.00KB |
-|   deas-0.28.0 |       418.24 |     117.63KB |
-|   deas-0.27.0 |       404.93 |     114.04KB |
-|   deas-0.25.0 |       417.49 |     117.15KB |
-| sinatra-1.4.5 |       440.80 |     123.82KB |
+|   deas-0.31.0 |       430.86 |     120.76KB |
+|   deas-0.29.0 |       423.75 |     119.04KB |
+|   deas-0.28.0 |       408.36 |     114.73KB |
+|   deas-0.27.0 |       437.01 |     122.48KB |
+|   deas-0.25.0 |       430.22 |     120.85KB |
+| sinatra-1.4.5 |       453.31 |     127.46KB |
 
 ### 02_erb_basic
 
@@ -22,11 +23,12 @@ Single endpoint rendering with no partials or layouts.
 
 |    Version    | Requests/sec | Transfer/sec |
 | ------------- | ------------ | ------------ |
-|   deas-0.29.0 |       356.52 |     117.82KB |
-|   deas-0.28.0 |       323.01 |     106.75KB |
-|   deas-0.27.0 |       348.29 |     114.96KB |
-|   deas-0.25.0 |       348.03 |     115.02KB |
-| sinatra-1.4.5 |       366.94 |     121.12KB |
+|   deas-0.31.0 |       401.50 |     132.66KB |
+|   deas-0.29.0 |       378.01 |     125.05KB |
+|   deas-0.28.0 |       345.73 |     114.39KB |
+|   deas-0.27.0 |       367.40 |     121.55KB |
+|   deas-0.25.0 |       361.68 |     119.52KB |
+| sinatra-1.4.5 |       378.87 |     125.33KB |
 
 ### 03_erb_partial
 
@@ -34,11 +36,12 @@ Single endpoint rendering a partial with no layout.
 
 |    Version    | Requests/sec | Transfer/sec |
 | ------------- | ------------ | ------------ |
-|   deas-0.29.0 |       347.44 |     131.79KB |
-|   deas-0.28.0 |       292.33 |     110.90KB |
-|   deas-0.27.0 |       310.93 |     117.95KB |
-|   deas-0.25.0 |       307.21 |     116.68KB |
-| sinatra-1.4.5 |       322.33 |     122.27KB |
+|   deas-0.31.0 |       401.78 |     152.93KB |
+|   deas-0.29.0 |       359.35 |     136.44KB |
+|   deas-0.28.0 |       310.37 |     117.74KB |
+|   deas-0.27.0 |       315.94 |     119.85KB |
+|   deas-0.25.0 |       324.00 |     122.90KB |
+| sinatra-1.4.5 |       328.43 |     124.58KB |
 
 ### 04_erb_layout
 
@@ -46,11 +49,12 @@ Single endpoint rendering in a layout.
 
 |    Version    | Requests/sec | Transfer/sec |
 | ------------- | ------------ | ------------ |
-|   deas-0.29.0 |       318.90 |     117.37KB |
-|   deas-0.28.0 |       291.88 |     107.59KB |
-|   deas-0.27.0 |       316.45 |     116.61KB |
-|   deas-0.25.0 |       317.88 |     117.13KB |
-| sinatra-1.4.5 |       312.37 |     115.11KB |
+|   deas-0.31.0 |       377.67 |     139.23KB |
+|   deas-0.29.0 |       328.40 |     120.86KB |
+|   deas-0.28.0 |       314.84 |     116.02KB |
+|   deas-0.27.0 |       319.87 |     117.73KB |
+|   deas-0.25.0 |       325.91 |     119.81KB |
+| sinatra-1.4.5 |       333.98 |     122.77KB |
 
 ### 05_erb_layout_partial
 
@@ -58,11 +62,12 @@ Single endpoint rendering a partial in a layout.
 
 |    Version    | Requests/sec | Transfer/sec |
 | ------------- | ------------ | ------------ |
-|   deas-0.29.0 |       299.86 |     123.11KB |
-|   deas-0.28.0 |       281.80 |     115.59KB |
-|   deas-0.27.0 |       283.48 |     116.27KB |
-|   deas-0.25.0 |       274.93 |     112.50KB |
-| sinatra-1.4.5 |       309.77 |     126.75KB |
+|   deas-0.31.0 |       383.91 |     157.36KB |
+|   deas-0.29.0 |       320.99 |     131.62KB |
+|   deas-0.28.0 |       288.86 |     118.34KB |
+|   deas-0.27.0 |       296.02 |     121.40KB |
+|   deas-0.25.0 |       299.37 |     122.91KB |
+| sinatra-1.4.5 |       321.89 |     131.71KB |
 
 ### 06_hello_many_routes
 
@@ -70,11 +75,12 @@ Single endpoint rendering a partial in a layout.
 
 |    Version    | Requests/sec | Transfer/sec |
 | ------------- | ------------ | ------------ |
-|   deas-0.29.0 |       300.76 |      84.43KB |
-|   deas-0.28.0 |       300.38 |      84.33KB |
-|   deas-0.27.0 |       300.80 |      84.30KB |
-|   deas-0.25.0 |       304.89 |      85.45KB |
-| sinatra-1.4.5 |       320.88 |      90.35KB |
+|   deas-0.31.0 |       318.83 |      89.50KB |
+|   deas-0.29.0 |       320.44 |      89.95KB |
+|   deas-0.28.0 |       316.95 |      89.38KB |
+|   deas-0.27.0 |       321.30 |      90.19KB |
+|   deas-0.25.0 |       321.90 |      90.36KB |
+| sinatra-1.4.5 |       320.44 |      90.22KB |
 
 ## Usage
 


### PR DESCRIPTION
Just adding another version for comparison.  This version uses
the template source and deas-erubis to render erb.  Outperforms
all other deas versions in all cases.  Outperforms sinatra in all
rendering cases.

@jcredding FYI.